### PR TITLE
Updated -carry option.

### DIFF
--- a/src/Compiler/CompilerRS.cpp
+++ b/src/Compiler/CompilerRS.cpp
@@ -148,8 +148,8 @@ std::string CompilerRS::FinishSynthesisScript(const std::string& script) {
     case SynthesisCarryInference::All:
       carry_inference = "-carry all";
       break;
-    case SynthesisCarryInference::NoConst:
-      carry_inference = "-carry no_const";
+    case SynthesisCarryInference::Auto:
+      carry_inference = "-carry auto";
       break;
     case SynthesisCarryInference::NoCarry:
       carry_inference = "-carry no";
@@ -240,8 +240,8 @@ bool CompilerRS::RegisterCommands(TclInterpreter* interp, bool batchMode) {
         std::string arg = argv[++i];
         if (arg == "none") {
           compiler->SynthCarry(SynthesisCarryInference::NoCarry);
-        } else if (arg == "no_const") {
-          compiler->SynthCarry(SynthesisCarryInference::NoConst);
+        } else if (arg == "auto") {
+          compiler->SynthCarry(SynthesisCarryInference::Auto);
         } else if (arg == "all") {
           compiler->SynthCarry(SynthesisCarryInference::All);
         } else {
@@ -388,7 +388,7 @@ void CompilerRS::Help(std::ostream* out) {
   (*out) << "                              :   -fsm_encoding binary if "
             "optimization == area else onehot"
          << std::endl;
-  (*out) << "                              :   -carry no_const" << std::endl;
+  (*out) << "                              :   -carry auto" << std::endl;
   (*out) << "     -effort <level>          : Optimization effort level (high,"
             " medium, low)"
          << std::endl;
@@ -403,8 +403,8 @@ void CompilerRS::Help(std::ostream* out) {
          << std::endl;
   (*out) << "       all                    : Infer as much as possible"
          << std::endl;
-  (*out) << "       no_const               : Infer carries only with non "
-            "constant inputs"
+  (*out) << "       auto                   : Infer carries based on internal "
+            "heuristics"
          << std::endl;
   (*out) << "       none                   : Do not infer carries" << std::endl;
   (*out) << "     -no_dsp                  : Do not use DSP blocks to "

--- a/src/Compiler/CompilerRS.h
+++ b/src/Compiler/CompilerRS.h
@@ -19,7 +19,7 @@ namespace FOEDAG {
 class CompilerRS : public CompilerOpenFPGA {
  public:
   enum class SynthesisEffort { None, High, Low, Medium };
-  enum class SynthesisCarryInference { None, NoCarry, All, NoConst };
+  enum class SynthesisCarryInference { None, NoCarry, All, Auto };
   enum class SynthesisFsmEncoding { None, Binary, Onehot };
 
  public:


### PR DESCRIPTION
The supported values for the `-carry` option has been updated in the latest `yosys_verific_rs` . This change is aimed to update the option in FOEDAG_rs/Raptor as well. In `Raptor` repository `yosys_verific_rs` submodule should be updated together with `FOEDAG_rs` at the same time.