### PR TITLE
Force usage of DE optimization.

### DIFF
--- a/src/Compiler/CompilerRS.cpp
+++ b/src/Compiler/CompilerRS.cpp
@@ -551,6 +551,6 @@ bool CompilerRS::LicenseDevice(const std::string& deviceName) {
   // cannot be checkedout. deviceName is "GEMINI or MPW1" at this point.
   // Properly transform the string to the "RaptorGemini" feature before invoking
   // the License manager
-  
+
   return true;
 }


### PR DESCRIPTION
As discussed with @thierryBesson we force usage of "DE" in July release.