### PR TITLE
[RG-76] Hyperlink removed from about dialog

### DIFF
--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -17,7 +17,7 @@ QWidget* mainWindowBuilder(FOEDAG::Session* session) {
   FOEDAG::MainWindow* mainW = new FOEDAG::MainWindow{session};
   auto info = mainW->Info();
   info.name = QString("%1").arg(ToolName);
-  info.url = "https://github.com/RapidSilicon/FOEDAG_rs/commit/";
+  info.url.clear();
   mainW->Info(info);
   return mainW;
 }


### PR DESCRIPTION
**Motivation of Pull Request**
Remove commit hyperlink from foedag_rs's about dialog

**What is currently done?**
Hyperlink is removed from the about Dialog. 