### PR TITLE
Bring ssh-agent to latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: ssh-agent
       if: matrix.mode == 'production'
-      uses: webfactory/ssh-agent@v0.5.4
+      uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_RAPTOR_TOOLS }}


### PR DESCRIPTION
Node 16 support was added in v0.6.0
https://github.com/webfactory/ssh-agent/releases
