### PR TITLE
Fixed ubuntu version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
   linux-gcc:
     name: ${{ matrix.mode }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -129,7 +129,7 @@ jobs:
   centos7-gcc:
     name:  ${{ matrix.mode }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: centos:7
     defaults:


### PR DESCRIPTION
Because of this https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/
We need to fix version to ubuntu 20.04