### PR TITLE
[RG-222] convert missed (*m_out) prints to Message()

### DIFF
--- a/src/Compiler/CompilerRS.cpp
+++ b/src/Compiler/CompilerRS.cpp
@@ -127,7 +127,7 @@ std::string CompilerRS::FinishSynthesisScript(const std::string &script) {
   for (auto keep : m_constraints->GetKeeps()) {
     keep = ReplaceAll(keep, "@", "[");
     keep = ReplaceAll(keep, "%", "]");
-    (*m_out) << "Keep name: " << keep << "\n";
+    Message("Keep name: " + keep);
     keeps += "setattr -set keep 1 w:\\" + keep + "\n";
   }
   result = ReplaceAll(result, "${KEEP_NAMES}", keeps);
@@ -1036,8 +1036,7 @@ bool CompilerRS::TimingAnalysis() {
     return false;
   }
 
-  (*m_out) << "Design " << ProjManager()->projectName()
-           << " is timing analysed!" << std::endl;
+  Message("Design " + ProjManager()->projectName() + " is timing analysed!");
 
   return true;
 }


### PR DESCRIPTION
This switches two (*m_out) prints that were missed in previous RG-222 PRs to use Message(). This will allow those messages to have a log prefix when printed.