### PR TITLE
[RG-230] RS specific changes to disable global_placement

### DIFF
--- a/tests/TestBatch/test_compiler_batch.tcl
+++ b/tests/TestBatch/test_compiler_batch.tcl
@@ -20,11 +20,11 @@
 batch {
   synth
   packing
-  # globp
+  globp
 }
 
 after 22000 {set CONT 0}
-set CONT 1
+set CONT 1 
 while {$CONT} {
   set a 0
   after 100 set a 1

--- a/tests/TestBatch/test_compiler_mt.tcl
+++ b/tests/TestBatch/test_compiler_mt.tcl
@@ -18,12 +18,12 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 synthesize
-after 3000 {puts "STOP"; flush stdout ; stop}
+after 3000 {puts "STOP"; flush stdout ; stop} 
 after 5000 {synthesize}
 after 16000 {packing}
-# after 17000 {global_placement}
+after 17000 {global_placement}
 after 28000 {set CONT 0}
-set CONT 1
+set CONT 1 
 while {$CONT} {
   set a 0
   after 100 set a 1


### PR DESCRIPTION
### This is related to https://github.com/os-fpga/FOEDAG/pull/876. 

This removes the help entry for global_placement and comments out a call to global_placement in a test.