### PR TITLE
adding set_clock_pin for --help option

### DIFF
--- a/src/Compiler/CompilerRS.cpp
+++ b/src/Compiler/CompilerRS.cpp
@@ -653,8 +653,7 @@ void CompilerRS::Help(std::ostream *out) {
             "clk[0],clk[1]....,clk[15]."
          << std::endl;
   (*out) << "                                and e.g. user clocks are clk_a, "
-            "clk_b and want"
-            " to map clk_a with clk[15]"
+            "clk_b and want to map clk_a with clk[15]"
          << std::endl;
   (*out)
       << "                               Constraints : set clocks for repacking"


### PR DESCRIPTION
Gemini device supports 16 different physical clock inputs to FPGA fabric. This allows user to have design with 16 different clocks. This mapping between physical to logical happens by providing repacker.xml file. All the related discussion is in attached link below
[EDA-691](https://rapidsilicon.atlassian.net/browse/EDA-691).

[EDA-691]: https://rapidsilicon.atlassian.net/browse/EDA-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ