### PR TITLE
Set CompilerRs name

### DIFF
--- a/src/Compiler/CompilerRS.cpp
+++ b/src/Compiler/CompilerRS.cpp
@@ -351,6 +351,7 @@ CompilerRS::CompilerRS() : CompilerOpenFPGA() {
   m_synthType = SynthesisType::RS;
   m_netlistType = NetlistType::Verilog;
   m_channel_width = 200;
+  m_name = "CompilerRS";
 }
 
 void CompilerRS::CustomSimulatorSetup(Simulator::SimulationType action) {


### PR DESCRIPTION
Setting the compiler name in the CompilerRs constructor. This is inline with https://github.com/os-fpga/FOEDAG/blob/0164c1e8e5bf5dbb2ffb429f2fe43ed914db8a07/src/Compiler/Compiler.h#L110