### PR TITLE
Revert "Uncommented the carry length flags"

### DIFF
--- a/src/Compiler/CompilerRS.cpp
+++ b/src/Compiler/CompilerRS.cpp
@@ -266,8 +266,8 @@ std::string CompilerRS::FinishSynthesisScript(const std::string &script) {
   limits += std::string("-max_device_bram ") +
             std::to_string(MaxDeviceBRAMCount()) + std::string(" ");
   // TODO, uncomment when supported in Synthesis
-  limits += std::string("-max_device_carry_length ") +
-            std::to_string(MaxDeviceCarryLength()) + std::string(" ");
+  // limits += std::string("-max_device_carry_length ") +
+  //          std::to_string(MaxDeviceCarryLength()) + std::string(" ");
   if (MaxUserDSPCount() >= 0)
     limits += std::string("-max_dsp ") + std::to_string(MaxUserDSPCount()) +
               std::string(" ");
@@ -275,9 +275,10 @@ std::string CompilerRS::FinishSynthesisScript(const std::string &script) {
     limits += std::string("-max_bram ") + std::to_string(MaxUserBRAMCount()) +
               std::string(" ");
   // TODO, uncomment when supported in Synthesis
-  if (MaxUserCarryLength() >= 0)
-    limits += std::string("-max_carry_length ") +
-              std::to_string(MaxUserCarryLength()) + std::string(" ");
+  // if (MaxUserCarryLength() >= 0)
+  //  limits += std::string("-max_carry_length ") +
+  //  std::to_string(MaxUserCarryLength()) +
+  //            std::string(" ");
 
   if (m_synthType == SynthesisType::QL) {
     optimization = "";


### PR DESCRIPTION
Reverts RapidSilicon/FOEDAG_rs#395

Reverting temporarily since the corresponding change in yosys_verific_rs does not work.
