### PR TITLE
Open tests for `openfile` tcl command

### DIFF
--- a/tests/TestGui/gui_foedag.tcl
+++ b/tests/TestGui/gui_foedag.tcl
@@ -20,8 +20,8 @@
 puts "GUI START" ; flush stdout ; gui_start
 puts "GUI STOP"  ; flush stdout ; gui_stop
 puts "GUI START" ; flush stdout ; gui_start
-#puts "TEXT EDITOR GUI OPENFILE"  ; flush stdout ; openfile tests/TestGui/test.v
-#puts "TEXT EDITOR GUI OPENFILE"  ; flush stdout ; openfile tests/TestGui/test.v
+puts "TEXT EDITOR GUI OPENFILE"  ; flush stdout ; openfile tests/TestGui/test.v
+puts "TEXT EDITOR GUI OPENFILE"  ; flush stdout ; openfile tests/TestGui/test.v
 
 puts "NEW PROJECT START" ; flush stdout ; newproject_gui_open
 puts "NEXT" ; flush stdout ; next


### PR DESCRIPTION
This test was disable during monaco editor integration. 
This test failed due to some crash which was fixed here https://github.com/os-fpga/FOEDAG/pull/1456