### PR TITLE
Rename nlohmann_json target to foedag_nlohmann_json to avoid name clash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ target_link_libraries(raptor_gui PUBLIC rs_licenseManager)
 	endif()
 endif()
 
-add_dependencies(raptor_gui nlohmann_json)
+add_dependencies(raptor_gui foedag_nlohmann_json)
 add_dependencies(raptor_gui scope_guard)
 add_dependencies(raptor_gui cfgcommonrs)
 

--- a/src/ConfigurationRS/CMakeLists.txt
+++ b/src/ConfigurationRS/CMakeLists.txt
@@ -158,6 +158,6 @@ target_link_libraries(bitgenerator INTERFACE cfgobject)
 target_link_libraries(bitassembler INTERFACE bitgenerator)
 target_link_libraries(ocla INTERFACE hardwaremanager)
 
-add_dependencies(bitassembler nlohmann_json)
-add_dependencies(bitgenerator nlohmann_json)
+add_dependencies(bitassembler foedag_nlohmann_json)
+add_dependencies(bitgenerator foedag_nlohmann_json)
 add_dependencies(cfgcrypto openssl_build)


### PR DESCRIPTION
Since nlohmann_json is used in other open-source projects, we have a name clash in the CMake target so just appending the prefix foedag to avoid the name clash.