### PR TITLE
Update OCLA IP new register address map

### DIFF
--- a/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
+++ b/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
@@ -478,7 +478,7 @@
       }
     },
     {
-      "debug": {
+      "read": {
         "option": [
           {
             "name": "cable",
@@ -497,52 +497,69 @@
             "help": "Specify the index of the device on the selected cable"
           },
           {
-            "name": "instance",
-            "short": "i",
+            "name": "addr",
+            "short": "a",
+            "type": "int",
+            "optional": false,
+            "help": "Specify address to read"
+          },
+          {
+            "name": "times",
+            "short": "t",
             "type": "int",
             "default" : 1,
             "optional": true,
-            "help": "Specify the index of the OCLA instance to debug"
+            "help": "Specify the number of time to read"
           },
           {
-            "name": "start",
-            "short": "s",
-            "type": "flag",
-            "default" : false,
+            "name": "increment",
+            "short": "i",
+            "type": "int",
+            "default" : 0,
             "optional": true,
-            "help": "Set ST bit of OCSR register"
+            "help": "Specify the number to advance the address after each read"
+          }
+        ],
+        "hidden": true,
+        "desc": "For software and IP debugging.",
+        "help": [
+          "For software and IP debugging"
+        ],
+        "arg": [0, 0]
+      }
+    },
+    {
+      "write": {
+        "option": [
+          {
+            "name": "cable",
+            "short": "b",
+            "type": "str",
+            "optional": true,
+            "default" : "1",
+            "help": "Specify the index of the cable"
           },
           {
-            "name": "dump",
-            "short": "u",
-            "type": "flag",
-            "default" : false,
+            "name": "device",
+            "short": "d",
+            "type": "int",
             "optional": true,
-            "help": "Dump trace buffer"
+            "default" : 1,
+            "help": "Specify the index of the device on the selected cable"
           },
           {
-            "name": "reg",
-            "short": "r",
-            "type": "flag",
-            "default" : false,
-            "optional": true,
-            "help": "Dump OCLA registers"
+            "name": "addr",
+            "short": "a",
+            "type": "int",
+            "optional": false,
+            "help": "Specify address to write"
           },
           {
-            "name": "waveform",
-            "short": "w",
-            "type": "flag",
-            "default" : false,
-            "optional": true,
-            "help": "Generate waveform"
-          },
-          {
-            "name": "session_info",
-            "short": "e",
-            "type": "flag",
-            "default" : false,
-            "optional": true,
-            "help": "Show session info"
+            "name": "value",
+            "short": "v",
+            "type": "int",
+            "optional": false,
+            "help": "Specify the value write"
           }
         ],
         "hidden": true,

--- a/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
+++ b/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
@@ -583,11 +583,11 @@
             ]
           },
           {
-            "name": "trigger_condition",
+            "name": "multi_trigger_bool",
             "short": "t",
             "type": "or|and|xor",
             "optional": true,
-            "help": "Configure the global trigger boolean condition"
+            "help": "Configure the multiple trigger boolean condition"
           },
           {
             "name": "cable",
@@ -671,6 +671,14 @@
             "type": "int",
             "optional": true,
             "help": "Trigger value that associate to trigger type when it is set to equal|lesser|greater"
+          },
+          {
+            "name": "value_compare_width",
+            "short": "w",
+            "type": "int",
+            "default": 1,
+            "optional": true,
+            "help": "Trigger value compare width in bits"
           },
           {
             "name": "probe",

--- a/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
+++ b/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
@@ -583,7 +583,7 @@
             ]
           },
           {
-            "name": "multi_trigger_bool",
+            "name": "trigger_condition",
             "short": "t",
             "type": "or|and|xor",
             "optional": true,
@@ -673,12 +673,12 @@
             "help": "Trigger value that associate to trigger type when it is set to equal|lesser|greater"
           },
           {
-            "name": "value_compare_width",
+            "name": "compare_width",
             "short": "w",
             "type": "int",
             "default": 1,
             "optional": true,
-            "help": "Trigger value compare width in bits"
+            "help": "Trigger compare value width in bits"
           },
           {
             "name": "probe",

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -125,7 +125,7 @@ Ocla::Ocla(OclaJtagAdapter* adapter, OclaSession* session,
   CFG_ASSERT(m_writer != nullptr);
 }
 
-void Ocla::configure(uint32_t instance, std::string mode, std::string boolcomp,
+void Ocla::configure(uint32_t instance, std::string mode, std::string condition,
                      uint32_t sample_size) {
   if (!validate()) {
     CFG_POST_ERR("OCLA info not matched with the detected OCLA IP");
@@ -143,11 +143,12 @@ void Ocla::configure(uint32_t instance, std::string mode, std::string boolcomp,
 
   ocla_config cfg;
 
-  std::transform(boolcomp.begin(), boolcomp.end(), boolcomp.begin(), ::toupper);
+  std::transform(condition.begin(), condition.end(), condition.begin(),
+                 ::toupper);
   cfg.enable_fix_sample_size = sample_size > 0 ? true : false;
   cfg.sample_size = sample_size;
   cfg.mode = convert_ocla_trigger_mode(mode);
-  cfg.boolcomp = convert_trigger_bool_comp(boolcomp);
+  cfg.condition = convert_trigger_condition(condition);
 
   ocla_ip.configure(cfg);
 }
@@ -295,8 +296,8 @@ std::string Ocla::show_info() {
     ss << "  No. of samples     : " << ns << std::endl
        << "  Trigger mode       : "
        << convert_ocla_trigger_mode_to_string(cfg.mode) << std::endl
-       << "  Multi-trigger bool : "
-       << convert_trigger_bool_comp_to_string(cfg.boolcomp) << std::endl
+       << "  Trigger condition  : "
+       << convert_trigger_condition_to_string(cfg.condition) << std::endl
        << "  Trigger " << std::endl
        << std::setfill(' ');
 

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -11,13 +11,14 @@
 #include "OclaWaveformWriter.h"
 
 #define OCLA_MAX_INSTANCE_COUNT (15)
-#define OCLA1_ADDR (0x02000000)
-#define OCLA2_ADDR (0x03000000)
-#define OCLA_TYPE ("ocla")
+#define OCLA1_ADDR (0x03000000)
+#define OCLA2_ADDR (0x04000000)
+#define OCLA3_ADDR (0x05000000)
+#define OCLA_TYPE ("OCLA")
 #define OCLA_MAX_PROBE (1024)
 
-static std::map<uint32_t, uint32_t> ocla_base_address = {{1, OCLA1_ADDR},
-                                                         {2, OCLA2_ADDR}};
+static std::map<uint32_t, uint32_t> ocla_base_address = {
+    {1, OCLA1_ADDR}, {2, OCLA2_ADDR}, {3, OCLA3_ADDR}};
 
 OclaIP Ocla::get_ocla_instance(uint32_t instance) {
   CFG_ASSERT(ocla_base_address.find(instance) != ocla_base_address.end());

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -322,6 +322,7 @@ std::string Ocla::show_info() {
              << "; compare_operator="
              << convert_trigger_event_to_string(trig_cfg.event)
              << "; compare_value=0x" << std::hex << trig_cfg.value << std::dec
+             << "; compare_value_width=" << trig_cfg.value_compare_width
              << std::endl;
           break;
         case TRIGGER_NONE:

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -144,8 +144,8 @@ void Ocla::configure(uint32_t instance, std::string mode, std::string boolcomp,
   ocla_config cfg;
 
   std::transform(boolcomp.begin(), boolcomp.end(), boolcomp.begin(), ::toupper);
-  cfg.fns = sample_size > 0 ? true : false;
-  cfg.ns = sample_size;
+  cfg.enable_fix_sample_size = sample_size > 0 ? true : false;
+  cfg.sample_size = sample_size;
   cfg.mode = convert_ocla_trigger_mode(mode);
   cfg.boolcomp = convert_trigger_bool_comp(boolcomp);
 
@@ -290,7 +290,7 @@ std::string Ocla::show_info() {
 
     auto cfg = ocla_ip.get_config();
 
-    uint32_t ns = cfg.fns ? cfg.ns : depth;
+    uint32_t ns = cfg.enable_fix_sample_size ? cfg.sample_size : depth;
 
     ss << "  No. of samples     : " << ns << std::endl
        << "  Trigger mode       : "

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -16,6 +16,7 @@
 #define OCLA3_ADDR (0x05000000)
 #define OCLA_TYPE ("OCLA")
 #define OCLA_MAX_PROBE (1024)
+#define OCLA_MIN_TRIGGER_COUNT (4)
 
 static std::map<uint32_t, uint32_t> ocla_base_address = {
     {1, OCLA1_ADDR}, {2, OCLA2_ADDR}, {3, OCLA3_ADDR}};
@@ -33,7 +34,13 @@ std::map<uint32_t, OclaIP> Ocla::detect_ocla_instances() {
   for (auto& [i, baseaddr] : ocla_base_address) {
     OclaIP ocla_ip{m_adapter, baseaddr};
     if (ocla_ip.get_type() == OCLA_TYPE) {
-      list.insert(std::pair<uint32_t, OclaIP>(i, ocla_ip));
+      auto trigger_count = ocla_ip.get_trigger_count();
+      if (trigger_count < OCLA_MIN_TRIGGER_COUNT) {
+        CFG_POST_WARNING("Invalid trigger count %d detected for instance %d",
+                         trigger_count, i);
+      } else {
+        list.insert(std::pair<uint32_t, OclaIP>(i, ocla_ip));
+      }
     }
   }
 

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -146,7 +146,8 @@ void Ocla::configure(uint32_t instance, std::string mode, std::string boolcomp,
 
 void Ocla::configure_channel(uint32_t instance, uint32_t channel,
                              std::string type, std::string event,
-                             uint32_t value, std::string probe) {
+                             uint32_t value, uint32_t value_compare_width,
+                             std::string probe) {
   if (!validate()) {
     CFG_POST_ERR("OCLA info not matched with the detected OCLA IP");
     return;
@@ -206,6 +207,7 @@ void Ocla::configure_channel(uint32_t instance, uint32_t channel,
   trig_cfg.type = convert_trigger_type(type);
   trig_cfg.event = convert_trigger_event(event);
   trig_cfg.value = value;
+  trig_cfg.value_compare_width = value_compare_width;
 
   ocla_ip.configure_channel(channel - 1, trig_cfg);
 }

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -425,65 +425,6 @@ std::string Ocla::show_session_info() {
   return ss.str();
 }
 
-std::string Ocla::dump_registers(uint32_t instance) {
-  std::map<uint32_t, std::string> regs = {
-      {OCSR, "OCSR"},
-      //{TCUR0, "TCUR0"},
-      {TMTR, "TMTR"},
-      //{TDCR, "TDCR"},
-      // {TCUR1, "TCUR1"},
-      {IP_TYPE, "IP_TYPE"},
-      {IP_VERSION, "IP_VERSION"},
-      {IP_ID, "IP_ID"},
-  };
-
-  OclaIP ocla_ip = get_ocla_instance(instance);
-  std::ostringstream ss;
-  char buffer[100];
-
-  for (auto const& [offset, name] : regs) {
-    uint32_t regaddr = ocla_ip.get_base_addr() + offset;
-    snprintf(buffer, sizeof(buffer), "%-10s (0x%08x) = 0x%08x\n", name.c_str(),
-             regaddr, m_adapter->read(regaddr));
-    ss << buffer;
-  }
-
-  return ss.str();
-}
-
-std::string Ocla::dump_samples(uint32_t instance, bool dumpText,
-                               bool generate_waveform) {
-  OclaIP ocla_ip = get_ocla_instance(instance);
-  std::ostringstream ss;
-  char buffer[100];
-  auto data = ocla_ip.get_data();
-
-  if (dumpText) {
-    ss << "width " << data.width << " depth " << data.depth << " num_reads "
-       << data.num_reads << " length " << data.values.size() << std::endl;
-    for (auto& value : data.values) {
-      snprintf(buffer, sizeof(buffer), "0x%08x\n", value);
-      ss << buffer;
-    }
-  }
-
-  if (generate_waveform) {
-    std::string filepath = "/tmp/ocla_debug.fst";
-    m_writer->set_width(data.width);
-    m_writer->set_depth(data.depth);
-    m_writer->set_signals(generate_signal_descriptor(data.width));
-    m_writer->write(data.values, filepath.c_str());
-    ss << "Waveform written to " << filepath << std::endl;
-  }
-
-  return ss.str();
-}
-
-void Ocla::debug_start(uint32_t instance) {
-  OclaIP ocla_ip = get_ocla_instance(instance);
-  ocla_ip.start();
-}
-
 std::string Ocla::show_status(uint32_t instance) {
   OclaIP ocla_ip = get_ocla_instance(instance);
   std::ostringstream ss;

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -285,7 +285,7 @@ std::string Ocla::show_info() {
     ss << "  No. of samples     : " << ns << std::endl
        << "  Trigger mode       : "
        << convert_ocla_trigger_mode_to_string(cfg.mode) << std::endl
-       << "  Trigger bool comparision  : "
+       << "  Multi-trigger bool : "
        << convert_trigger_bool_comp_to_string(cfg.boolcomp) << std::endl
        << "  Trigger " << std::endl
        << std::setfill(' ');

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -154,7 +154,7 @@ void Ocla::configure(uint32_t instance, std::string mode, std::string boolcomp,
 
 void Ocla::configure_channel(uint32_t instance, uint32_t channel,
                              std::string type, std::string event,
-                             uint32_t value, uint32_t value_compare_width,
+                             uint32_t value, uint32_t compare_width,
                              std::string probe) {
   if (!validate()) {
     CFG_POST_ERR("OCLA info not matched with the detected OCLA IP");
@@ -215,7 +215,7 @@ void Ocla::configure_channel(uint32_t instance, uint32_t channel,
   trig_cfg.type = convert_trigger_type(type);
   trig_cfg.event = convert_trigger_event(event);
   trig_cfg.value = value;
-  trig_cfg.value_compare_width = value_compare_width;
+  trig_cfg.compare_width = compare_width;
 
   ocla_ip.configure_channel(channel - 1, trig_cfg);
 }
@@ -329,8 +329,7 @@ std::string Ocla::show_info() {
              << "; compare_operator="
              << convert_trigger_event_to_string(trig_cfg.event)
              << "; compare_value=0x" << std::hex << trig_cfg.value << std::dec
-             << "; compare_value_width=" << trig_cfg.value_compare_width
-             << std::endl;
+             << "; compare_width=" << trig_cfg.compare_width << std::endl;
           break;
         case TRIGGER_NONE:
           ss << "    Channel " << ch << "        : "

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -21,7 +21,8 @@ class Ocla {
   void configure(uint32_t instance, std::string mode, std::string condition,
                  uint32_t sample_size);
   void configure_channel(uint32_t instance, uint32_t channel, std::string type,
-                         std::string event, uint32_t value, std::string probe);
+                         std::string event, uint32_t value,
+                         uint32_t value_compare_width, std::string probe);
   bool start(uint32_t instance, uint32_t timeout, std::string output_filepath);
   void start_session(std::string bitasm_filepath);
   void stop_session();

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -29,11 +29,6 @@ class Ocla {
   std::string show_status(uint32_t instance);
   std::string show_info();
   std::string show_session_info();
-  // debug use
-  std::string dump_registers(uint32_t instance);
-  std::string dump_samples(uint32_t instance, bool dump_text,
-                           bool generate_waveform);
-  void debug_start(uint32_t instance);
 
  private:
   OclaIP get_ocla_instance(uint32_t instance);

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -22,7 +22,7 @@ class Ocla {
                  uint32_t sample_size);
   void configure_channel(uint32_t instance, uint32_t channel, std::string type,
                          std::string event, uint32_t value,
-                         uint32_t value_compare_width, std::string probe);
+                         uint32_t compare_width, std::string probe);
   bool start(uint32_t instance, uint32_t timeout, std::string output_filepath);
   void start_session(std::string bitasm_filepath);
   void stop_session();

--- a/src/ConfigurationRS/Ocla/OclaHelpers.cpp
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.cpp
@@ -6,8 +6,8 @@ static std::map<ocla_trigger_mode, std::string>
                                        {POST, "post-trigger"},
                                        {CENTER, "center-trigger"}};
 
-static std::map<ocla_trigger_bool_comp, std::string>
-    trigger_bool_comp_to_string_map = {
+static std::map<ocla_trigger_condition, std::string>
+    trigger_condition_to_string_map = {
         {OR, "OR"}, {AND, "AND"}, {DEFAULT, "OR"}, {XOR, "XOR"}};
 
 static std::map<ocla_trigger_type, std::string> trigger_type_to_string_map = {
@@ -31,11 +31,11 @@ std::string convert_ocla_trigger_mode_to_string(ocla_trigger_mode mode,
   return defval;
 }
 
-std::string convert_trigger_bool_comp_to_string(ocla_trigger_bool_comp boolcomp,
-                                                std::string defval) {
-  if (trigger_bool_comp_to_string_map.find(boolcomp) !=
-      trigger_bool_comp_to_string_map.end())
-    return trigger_bool_comp_to_string_map[boolcomp];
+std::string convert_trigger_condition_to_string(
+    ocla_trigger_condition condition, std::string defval) {
+  if (trigger_condition_to_string_map.find(condition) !=
+      trigger_condition_to_string_map.end())
+    return trigger_condition_to_string_map[condition];
   return defval;
 }
 
@@ -64,9 +64,9 @@ ocla_trigger_mode convert_ocla_trigger_mode(std::string mode_string,
   return defval;
 }
 
-ocla_trigger_bool_comp convert_trigger_bool_comp(
-    std::string condition_string, ocla_trigger_bool_comp defval) {
-  for (auto& [condition, str] : trigger_bool_comp_to_string_map) {
+ocla_trigger_condition convert_trigger_condition(
+    std::string condition_string, ocla_trigger_condition defval) {
+  for (auto& [condition, str] : trigger_condition_to_string_map) {
     if (condition_string == str) return condition;
   }
   // default if not found

--- a/src/ConfigurationRS/Ocla/OclaHelpers.cpp
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.cpp
@@ -1,13 +1,13 @@
 #include "OclaHelpers.h"
 
-static std::map<ocla_mode, std::string> ocla_mode_to_string_map = {
-    {NO_TRIGGER, "disable"},
-    {PRE, "pre-trigger"},
-    {POST, "post-trigger"},
-    {CENTER, "center-trigger"}};
+static std::map<ocla_trigger_mode, std::string>
+    ocla_trigger_mode_to_string_map = {{CONTINUOUS, "disable"},
+                                       {PRE, "pre-trigger"},
+                                       {POST, "post-trigger"},
+                                       {CENTER, "center-trigger"}};
 
-static std::map<ocla_trigger_condition, std::string>
-    trigger_condition_to_string_map = {
+static std::map<ocla_trigger_bool_comp, std::string>
+    trigger_bool_comp_to_string_map = {
         {OR, "OR"}, {AND, "AND"}, {DEFAULT, "OR"}, {XOR, "XOR"}};
 
 static std::map<ocla_trigger_type, std::string> trigger_type_to_string_map = {
@@ -23,17 +23,19 @@ static std::map<ocla_trigger_event, std::string> trigger_event_to_string_map = {
     {GREATER, "greater"}};
 
 // helpers to convert enum to string and vice versa
-std::string convert_ocla_mode_to_string(ocla_mode mode, std::string defval) {
-  if (ocla_mode_to_string_map.find(mode) != ocla_mode_to_string_map.end())
-    return ocla_mode_to_string_map[mode];
+std::string convert_ocla_trigger_mode_to_string(ocla_trigger_mode mode,
+                                                std::string defval) {
+  if (ocla_trigger_mode_to_string_map.find(mode) !=
+      ocla_trigger_mode_to_string_map.end())
+    return ocla_trigger_mode_to_string_map[mode];
   return defval;
 }
 
-std::string convert_trigger_condition_to_string(
-    ocla_trigger_condition condition, std::string defval) {
-  if (trigger_condition_to_string_map.find(condition) !=
-      trigger_condition_to_string_map.end())
-    return trigger_condition_to_string_map[condition];
+std::string convert_trigger_bool_comp_to_string(ocla_trigger_bool_comp boolcomp,
+                                                std::string defval) {
+  if (trigger_bool_comp_to_string_map.find(boolcomp) !=
+      trigger_bool_comp_to_string_map.end())
+    return trigger_bool_comp_to_string_map[boolcomp];
   return defval;
 }
 
@@ -53,17 +55,18 @@ std::string convert_trigger_event_to_string(ocla_trigger_event trig_event,
   return defval;
 }
 
-ocla_mode convert_ocla_mode(std::string mode_string, ocla_mode defval) {
-  for (auto& [mode, str] : ocla_mode_to_string_map) {
+ocla_trigger_mode convert_ocla_trigger_mode(std::string mode_string,
+                                            ocla_trigger_mode defval) {
+  for (auto& [mode, str] : ocla_trigger_mode_to_string_map) {
     if (mode_string == str) return mode;
   }
   // default if not found
   return defval;
 }
 
-ocla_trigger_condition convert_trigger_condition(
-    std::string condition_string, ocla_trigger_condition defval) {
-  for (auto& [condition, str] : trigger_condition_to_string_map) {
+ocla_trigger_bool_comp convert_trigger_bool_comp(
+    std::string condition_string, ocla_trigger_bool_comp defval) {
+  for (auto& [condition, str] : trigger_bool_comp_to_string_map) {
     if (condition_string == str) return condition;
   }
   // default if not found

--- a/src/ConfigurationRS/Ocla/OclaHelpers.h
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.h
@@ -8,11 +8,11 @@
 #include "OclaSession.h"
 #include "OclaWaveformWriter.h"
 
-std::string convert_ocla_mode_to_string(ocla_mode mode,
-                                        std::string defval = "(unknown)");
+std::string convert_ocla_trigger_mode_to_string(
+    ocla_trigger_mode mode, std::string defval = "(unknown)");
 
-std::string convert_trigger_condition_to_string(
-    ocla_trigger_condition condition, std::string defval = "(unknown)");
+std::string convert_trigger_bool_comp_to_string(
+    ocla_trigger_bool_comp boolcomp, std::string defval = "(unknown)");
 
 std::string convert_trigger_type_to_string(ocla_trigger_type trig_type,
                                            std::string defval = "(unknown)");
@@ -20,11 +20,11 @@ std::string convert_trigger_type_to_string(ocla_trigger_type trig_type,
 std::string convert_trigger_event_to_string(ocla_trigger_event trig_event,
                                             std::string defval = "(unknown)");
 
-ocla_mode convert_ocla_mode(std::string mode_string,
-                            ocla_mode defval = NO_TRIGGER);
+ocla_trigger_mode convert_ocla_trigger_mode(
+    std::string mode_string, ocla_trigger_mode defval = CONTINUOUS);
 
-ocla_trigger_condition convert_trigger_condition(
-    std::string condition_string, ocla_trigger_condition defval = DEFAULT);
+ocla_trigger_bool_comp convert_trigger_bool_comp(
+    std::string condition_string, ocla_trigger_bool_comp defval = DEFAULT);
 
 ocla_trigger_type convert_trigger_type(std::string type_string,
                                        ocla_trigger_type defval = TRIGGER_NONE);

--- a/src/ConfigurationRS/Ocla/OclaHelpers.h
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.h
@@ -11,8 +11,8 @@
 std::string convert_ocla_trigger_mode_to_string(
     ocla_trigger_mode mode, std::string defval = "(unknown)");
 
-std::string convert_trigger_bool_comp_to_string(
-    ocla_trigger_bool_comp boolcomp, std::string defval = "(unknown)");
+std::string convert_trigger_condition_to_string(
+    ocla_trigger_condition condition, std::string defval = "(unknown)");
 
 std::string convert_trigger_type_to_string(ocla_trigger_type trig_type,
                                            std::string defval = "(unknown)");
@@ -23,8 +23,8 @@ std::string convert_trigger_event_to_string(ocla_trigger_event trig_event,
 ocla_trigger_mode convert_ocla_trigger_mode(
     std::string mode_string, ocla_trigger_mode defval = CONTINUOUS);
 
-ocla_trigger_bool_comp convert_trigger_bool_comp(
-    std::string condition_string, ocla_trigger_bool_comp defval = DEFAULT);
+ocla_trigger_condition convert_trigger_condition(
+    std::string condition_string, ocla_trigger_condition defval = DEFAULT);
 
 ocla_trigger_type convert_trigger_type(std::string type_string,
                                        ocla_trigger_type defval = TRIGGER_NONE);

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -102,12 +102,12 @@ void OclaIP::configure_channel(uint32_t channel, ocla_trigger_config &cfg) {
                            ((uint32_t)cfg.event & 0xf));
       break;
     case VALUE_COMPARE:
-      CFG_ASSERT(cfg.value_bitwidth > 0);
-      CFG_ASSERT(cfg.value_bitwidth <= get_max_compare_value_size());
+      CFG_ASSERT(cfg.value_compare_width > 0);
+      CFG_ASSERT(cfg.value_compare_width <= get_max_compare_value_size());
       CFG_set_bitfield_u32(&reg.tcur, TCUR_VC_Pos, TCUR_VC_Width,
                            ((uint32_t)cfg.event & 0xf));
       CFG_set_bitfield_u32(&reg.tssr, TSSR_CW_Pos, TSSR_CW_Width,
-                           cfg.value_bitwidth - 1);
+                           cfg.value_compare_width - 1);
       reg.tdcr = cfg.value;
       break;
     case TRIGGER_NONE:
@@ -193,7 +193,7 @@ ocla_trigger_config OclaIP::get_channel_config(uint32_t channel) const {
   ocla_trigger_config cfg;
   cfg.probe_num = (reg.tssr & TSSR_PS_Msk) >> TSSR_PS_Pos;
   cfg.type = (ocla_trigger_type)((reg.tcur & TCUR_TT_Msk) >> TCUR_TT_Pos);
-  cfg.value_bitwidth = 0;
+  cfg.value_compare_width = 0;
   cfg.value = 0;
 
   switch (cfg.type) {
@@ -209,7 +209,7 @@ ocla_trigger_config OclaIP::get_channel_config(uint32_t channel) const {
       cfg.event = (ocla_trigger_event)(
           ((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) | 0x30);
       cfg.value = reg.tdcr;
-      cfg.value_bitwidth = ((reg.tssr & TSSR_CW_Msk) >> TSSR_CW_Pos) + 1;
+      cfg.value_compare_width = ((reg.tssr & TSSR_CW_Msk) >> TSSR_CW_Pos) + 1;
       break;
     case TRIGGER_NONE:
       cfg.event = ocla_trigger_event::NONE;

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -102,12 +102,12 @@ void OclaIP::configure_channel(uint32_t channel, ocla_trigger_config &cfg) {
                            ((uint32_t)cfg.event & 0xf));
       break;
     case VALUE_COMPARE:
-      CFG_ASSERT(cfg.value_compare_width > 0);
-      CFG_ASSERT(cfg.value_compare_width <= get_max_compare_value_size());
+      CFG_ASSERT(cfg.compare_width > 0);
+      CFG_ASSERT(cfg.compare_width <= get_max_compare_value_size());
       CFG_set_bitfield_u32(reg.tcur, TCUR_VC_Pos, TCUR_VC_Width,
                            ((uint32_t)cfg.event & 0xf));
       CFG_set_bitfield_u32(reg.tssr, TSSR_CW_Pos, TSSR_CW_Width,
-                           cfg.value_compare_width - 1);
+                           cfg.compare_width - 1);
       reg.tdcr = cfg.value;
       break;
     case TRIGGER_NONE:
@@ -193,7 +193,7 @@ ocla_trigger_config OclaIP::get_channel_config(uint32_t channel) const {
   ocla_trigger_config cfg;
   cfg.probe_num = (reg.tssr & TSSR_PS_Msk) >> TSSR_PS_Pos;
   cfg.type = (ocla_trigger_type)((reg.tcur & TCUR_TT_Msk) >> TCUR_TT_Pos);
-  cfg.value_compare_width = 0;
+  cfg.compare_width = 0;
   cfg.value = 0;
 
   switch (cfg.type) {
@@ -209,7 +209,7 @@ ocla_trigger_config OclaIP::get_channel_config(uint32_t channel) const {
       cfg.event = (ocla_trigger_event)(
           ((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) | 0x30);
       cfg.value = reg.tdcr;
-      cfg.value_compare_width = ((reg.tssr & TSSR_CW_Msk) >> TSSR_CW_Pos) + 1;
+      cfg.compare_width = ((reg.tssr & TSSR_CW_Msk) >> TSSR_CW_Pos) + 1;
       break;
     case TRIGGER_NONE:
       cfg.event = ocla_trigger_event::NONE;

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -8,11 +8,11 @@ uint32_t CFG_reverse_byte_order_u32(uint32_t value) {
          (value << 24);
 }
 
-void CFG_set_bitfield_u32(uint32_t *value, uint8_t pos, uint8_t width,
+void CFG_set_bitfield_u32(uint32_t &value, uint8_t pos, uint8_t width,
                           uint32_t data) {
   uint32_t mask = (~0u >> (32 - width)) << pos;
-  *value &= ~mask;
-  *value |= (data & ((1u << width) - 1)) << pos;
+  value &= ~mask;
+  value |= (data & ((1u << width) - 1)) << pos;
 }
 
 OclaIP::OclaIP(OclaJtagAdapter *adapter, uint32_t base_addr)
@@ -73,11 +73,11 @@ uint32_t OclaIP::get_id() const { return m_id; }
 void OclaIP::configure(ocla_config &cfg) {
   CFG_ASSERT(m_adapter != nullptr);
 
-  CFG_set_bitfield_u32(&m_tmtr, TMTR_TM_Pos, TMTR_B_Width, (uint32_t)cfg.mode);
-  CFG_set_bitfield_u32(&m_tmtr, TMTR_B_Pos, TMTR_B_Width,
+  CFG_set_bitfield_u32(m_tmtr, TMTR_TM_Pos, TMTR_B_Width, (uint32_t)cfg.mode);
+  CFG_set_bitfield_u32(m_tmtr, TMTR_B_Pos, TMTR_B_Width,
                        (uint32_t)cfg.boolcomp);
-  CFG_set_bitfield_u32(&m_tmtr, TMTR_FNS_Pos, TMTR_FNS_Width, cfg.fns ? 1 : 0);
-  CFG_set_bitfield_u32(&m_tmtr, TMTR_NS_Pos, TMTR_NS_Width, (cfg.ns - 1));
+  CFG_set_bitfield_u32(m_tmtr, TMTR_FNS_Pos, TMTR_FNS_Width, cfg.fns ? 1 : 0);
+  CFG_set_bitfield_u32(m_tmtr, TMTR_NS_Pos, TMTR_NS_Width, (cfg.ns - 1));
 
   m_adapter->write(m_base_addr + TMTR, m_tmtr);
 }
@@ -88,25 +88,25 @@ void OclaIP::configure_channel(uint32_t channel, ocla_trigger_config &cfg) {
 
   ocla_channel_register reg = m_chregs[channel];
 
-  CFG_set_bitfield_u32(&reg.tcur, TCUR_TT_Pos, TCUR_TT_Width,
+  CFG_set_bitfield_u32(reg.tcur, TCUR_TT_Pos, TCUR_TT_Width,
                        (uint32_t)cfg.type);
-  CFG_set_bitfield_u32(&reg.tssr, TSSR_PS_Pos, TSSR_PS_Width, cfg.probe_num);
+  CFG_set_bitfield_u32(reg.tssr, TSSR_PS_Pos, TSSR_PS_Width, cfg.probe_num);
 
   switch (cfg.type) {
     case EDGE:
-      CFG_set_bitfield_u32(&reg.tcur, TCUR_ET_Pos, TCUR_ET_Width,
+      CFG_set_bitfield_u32(reg.tcur, TCUR_ET_Pos, TCUR_ET_Width,
                            ((uint32_t)cfg.event & 0xf));
       break;
     case LEVEL:
-      CFG_set_bitfield_u32(&reg.tcur, TCUR_LT_Pos, TCUR_LT_Width,
+      CFG_set_bitfield_u32(reg.tcur, TCUR_LT_Pos, TCUR_LT_Width,
                            ((uint32_t)cfg.event & 0xf));
       break;
     case VALUE_COMPARE:
       CFG_ASSERT(cfg.value_compare_width > 0);
       CFG_ASSERT(cfg.value_compare_width <= get_max_compare_value_size());
-      CFG_set_bitfield_u32(&reg.tcur, TCUR_VC_Pos, TCUR_VC_Width,
+      CFG_set_bitfield_u32(reg.tcur, TCUR_VC_Pos, TCUR_VC_Width,
                            ((uint32_t)cfg.event & 0xf));
-      CFG_set_bitfield_u32(&reg.tssr, TSSR_CW_Pos, TSSR_CW_Width,
+      CFG_set_bitfield_u32(reg.tssr, TSSR_CW_Pos, TSSR_CW_Width,
                            cfg.value_compare_width - 1);
       reg.tdcr = cfg.value;
       break;

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -145,9 +145,11 @@ ocla_data OclaIP::get_data() const {
 
   data.width = get_number_of_probes();
   data.num_reads = ((data.width - 1) / 32) + 1;
-  data.values =
+  auto result =
       m_adapter->read(m_base_addr + TBDR, data.depth * data.num_reads);
-
+  for (auto const &value : result) {
+    data.values.push_back(std::get<1>(value));
+  }
   return data;
 }
 

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -74,7 +74,8 @@ void OclaIP::configure(ocla_config &cfg) {
   CFG_ASSERT(m_adapter != nullptr);
 
   CFG_set_bitfield_u32(&m_tmtr, TMTR_TM_Pos, TMTR_B_Width, (uint32_t)cfg.mode);
-  CFG_set_bitfield_u32(&m_tmtr, TMTR_B_Pos, TMTR_B_Width, (uint32_t)cfg.boolcomp);
+  CFG_set_bitfield_u32(&m_tmtr, TMTR_B_Pos, TMTR_B_Width,
+                       (uint32_t)cfg.boolcomp);
   CFG_set_bitfield_u32(&m_tmtr, TMTR_FNS_Pos, TMTR_FNS_Width, cfg.fns ? 1 : 0);
   CFG_set_bitfield_u32(&m_tmtr, TMTR_NS_Pos, TMTR_NS_Width, (cfg.ns - 1));
 
@@ -87,21 +88,26 @@ void OclaIP::configure_channel(uint32_t channel, ocla_trigger_config &cfg) {
 
   ocla_channel_register reg = m_chregs[channel];
 
-  CFG_set_bitfield_u32(&reg.tcur, TCUR_TT_Pos, TCUR_TT_Width, (uint32_t)cfg.type);
+  CFG_set_bitfield_u32(&reg.tcur, TCUR_TT_Pos, TCUR_TT_Width,
+                       (uint32_t)cfg.type);
   CFG_set_bitfield_u32(&reg.tssr, TSSR_PS_Pos, TSSR_PS_Width, cfg.probe_num);
 
   switch (cfg.type) {
     case EDGE:
-      CFG_set_bitfield_u32(&reg.tcur, TCUR_ET_Pos, TCUR_ET_Width, ((uint32_t)cfg.event & 0xf));
+      CFG_set_bitfield_u32(&reg.tcur, TCUR_ET_Pos, TCUR_ET_Width,
+                           ((uint32_t)cfg.event & 0xf));
       break;
     case LEVEL:
-      CFG_set_bitfield_u32(&reg.tcur, TCUR_LT_Pos, TCUR_LT_Width, ((uint32_t)cfg.event & 0xf));
+      CFG_set_bitfield_u32(&reg.tcur, TCUR_LT_Pos, TCUR_LT_Width,
+                           ((uint32_t)cfg.event & 0xf));
       break;
     case VALUE_COMPARE:
       CFG_ASSERT(cfg.value_bitwidth > 0);
       CFG_ASSERT(cfg.value_bitwidth <= get_max_compare_value_size());
-      CFG_set_bitfield_u32(&reg.tcur, TCUR_VC_Pos, TCUR_VC_Width, ((uint32_t)cfg.event & 0xf));
-      CFG_set_bitfield_u32(&reg.tssr, TSSR_CW_Pos, TSSR_CW_Width, cfg.value_bitwidth - 1);
+      CFG_set_bitfield_u32(&reg.tcur, TCUR_VC_Pos, TCUR_VC_Width,
+                           ((uint32_t)cfg.event & 0xf));
+      CFG_set_bitfield_u32(&reg.tssr, TSSR_CW_Pos, TSSR_CW_Width,
+                           cfg.value_bitwidth - 1);
       reg.tdcr = cfg.value;
       break;
     case TRIGGER_NONE:
@@ -192,13 +198,16 @@ ocla_trigger_config OclaIP::get_channel_config(uint32_t channel) const {
 
   switch (cfg.type) {
     case EDGE:
-      cfg.event = (ocla_trigger_event)(((reg.tcur & TCUR_ET_Msk) >> TCUR_ET_Pos) | 0x10);
+      cfg.event = (ocla_trigger_event)(
+          ((reg.tcur & TCUR_ET_Msk) >> TCUR_ET_Pos) | 0x10);
       break;
     case LEVEL:
-      cfg.event = (ocla_trigger_event)(((reg.tcur & TCUR_LT_Msk) >> TCUR_LT_Pos) | 0x20);
+      cfg.event = (ocla_trigger_event)(
+          ((reg.tcur & TCUR_LT_Msk) >> TCUR_LT_Pos) | 0x20);
       break;
     case VALUE_COMPARE:
-      cfg.event = (ocla_trigger_event)(((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) | 0x30);
+      cfg.event = (ocla_trigger_event)(
+          ((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) | 0x30);
       cfg.value = reg.tdcr;
       cfg.value_bitwidth = ((reg.tssr & TSSR_CW_Msk) >> TSSR_CW_Pos) + 1;
       break;

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -75,7 +75,7 @@ void OclaIP::configure(ocla_config &cfg) {
 
   CFG_set_bitfield_u32(m_tmtr, TMTR_TM_Pos, TMTR_B_Width, (uint32_t)cfg.mode);
   CFG_set_bitfield_u32(m_tmtr, TMTR_B_Pos, TMTR_B_Width,
-                       (uint32_t)cfg.boolcomp);
+                       (uint32_t)cfg.condition);
   CFG_set_bitfield_u32(m_tmtr, TMTR_FNS_Pos, TMTR_FNS_Width,
                        cfg.enable_fix_sample_size ? 1 : 0);
   CFG_set_bitfield_u32(m_tmtr, TMTR_NS_Pos, TMTR_NS_Width,
@@ -180,7 +180,7 @@ ocla_config OclaIP::get_config() const {
   ocla_config cfg;
 
   cfg.mode = (ocla_trigger_mode)((m_tmtr & TMTR_TM_Msk) >> TMTR_TM_Pos);
-  cfg.boolcomp = (ocla_trigger_bool_comp)((m_tmtr & TMTR_B_Msk) >> TMTR_B_Pos);
+  cfg.condition = (ocla_trigger_condition)((m_tmtr & TMTR_B_Msk) >> TMTR_B_Pos);
   cfg.enable_fix_sample_size = ((m_tmtr & TMTR_FNS_Msk) >> TMTR_FNS_Pos);
   cfg.sample_size = ((m_tmtr & TMTR_NS_Msk) >> TMTR_NS_Pos) + 1;
 

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -76,8 +76,10 @@ void OclaIP::configure(ocla_config &cfg) {
   CFG_set_bitfield_u32(m_tmtr, TMTR_TM_Pos, TMTR_B_Width, (uint32_t)cfg.mode);
   CFG_set_bitfield_u32(m_tmtr, TMTR_B_Pos, TMTR_B_Width,
                        (uint32_t)cfg.boolcomp);
-  CFG_set_bitfield_u32(m_tmtr, TMTR_FNS_Pos, TMTR_FNS_Width, cfg.fns ? 1 : 0);
-  CFG_set_bitfield_u32(m_tmtr, TMTR_NS_Pos, TMTR_NS_Width, (cfg.ns - 1));
+  CFG_set_bitfield_u32(m_tmtr, TMTR_FNS_Pos, TMTR_FNS_Width,
+                       cfg.enable_fix_sample_size ? 1 : 0);
+  CFG_set_bitfield_u32(m_tmtr, TMTR_NS_Pos, TMTR_NS_Width,
+                       (cfg.sample_size - 1));
 
   m_adapter->write(m_base_addr + TMTR, m_tmtr);
 }
@@ -136,7 +138,7 @@ ocla_data OclaIP::get_data() const {
   ocla_data data;
 
   if (m_tmtr & TMTR_FNS_Msk) {
-    data.depth = get_config().ns;
+    data.depth = get_config().sample_size;
   } else {
     data.depth = get_memory_depth();
   }
@@ -179,8 +181,8 @@ ocla_config OclaIP::get_config() const {
 
   cfg.mode = (ocla_trigger_mode)((m_tmtr & TMTR_TM_Msk) >> TMTR_TM_Pos);
   cfg.boolcomp = (ocla_trigger_bool_comp)((m_tmtr & TMTR_B_Msk) >> TMTR_B_Pos);
-  cfg.fns = ((m_tmtr & TMTR_FNS_Msk) >> TMTR_FNS_Pos);
-  cfg.ns = ((m_tmtr & TMTR_NS_Msk) >> TMTR_NS_Pos) + 1;
+  cfg.enable_fix_sample_size = ((m_tmtr & TMTR_FNS_Msk) >> TMTR_FNS_Pos);
+  cfg.sample_size = ((m_tmtr & TMTR_NS_Msk) >> TMTR_NS_Pos) + 1;
 
   return cfg;
 }

--- a/src/ConfigurationRS/Ocla/OclaIP.h
+++ b/src/ConfigurationRS/Ocla/OclaIP.h
@@ -127,8 +127,8 @@ enum ocla_trigger_event {
 struct ocla_config {
   ocla_trigger_mode mode;
   ocla_trigger_bool_comp boolcomp;
-  bool fns;
-  uint32_t ns;
+  bool enable_fix_sample_size;
+  uint32_t sample_size;
 };
 
 struct ocla_trigger_config {

--- a/src/ConfigurationRS/Ocla/OclaIP.h
+++ b/src/ConfigurationRS/Ocla/OclaIP.h
@@ -5,32 +5,38 @@
 #include <string>
 #include <vector>
 
-#define OCLA1_ADDR (0x02000000U)
-#define OCLA2_ADDR (0x03000000U)
-#define OCLA_TYPE ("ocla")
-#define OCLA_TRIGGER_CHANNELS (4U)
-#define OCLA_MAX_SAMPLE_SIZE (1024U)
-#define OCLA_MAX_PROBE (128U)
-#define OCLA_MAX_INSTANCE_COUNT (2U)
-#define OCSR (0x00)
-#define TBDR (0x04)
-#define TCUR0 (0x08)
-#define TMTR (0x0C)
-#define TDCR (0x10)
-#define TCUR1 (0x14)
-#define IP_TYPE (0x18)
-#define IP_VERSION (0x1C)
-#define IP_ID (0x20)
+#define IP_TYPE (0x00)     // [RO] This register hold the IP Type "ocla"
+#define IP_VERSION (0x04)  // [RO] This register hold the IP Version
+#define IP_ID (0x08)       // [RO] This register hold the IP ID
+#define UIDP0 (0x14)       // [RO] Hold buffer size information
+#define UIDP1 (0x18)       // [RO] Hold number of Probes
+#define OCSR \
+  (0x20)  // [RO] Bitfields of OCSR contains configuration status of OCLA
+#define TMTR (0x24)  // [RW] TMCR is used configure trigger Modes
+#define TBDR \
+  (0x28)  // [RO] TBDR can be read to stream the whole acquisition data to some
+          // output interface
+#define OCCR \
+  (0x2C)  // [RW] This register will be used to start sampling or reset the IP
+          // core.
+#define TSSR \
+  (0x30)  // [RW] Channel 1. These registers will be used to select a probe
+          // across 1024 for trigger
+#define TCUR \
+  (0x34)  // [RW] Channel 1. These registers will be used to set triggers, that
+          // can be edge, level or value compared.  
+#define TDCR \
+  (0x38)  // [RW] Channel 1. Data that the user wants to compare with probe data
+          // will be written to this register.  
+#define MASK (0x3C)  // [RW] Channel 1. For disjoint probe comparision
 
 class OclaJtagAdapter;
 
 enum ocla_status { NA = 0, DATA_AVAILABLE = 1 };
 
-enum ocla_mode { NO_TRIGGER = 0, PRE = 1, POST = 2, CENTER = 3 };
+enum ocla_trigger_mode { CONTINUOUS = 0, PRE = 1, POST = 2, CENTER = 3 };
 
-enum ocla_fns { DISABLED = 0, ENABLED = 1 };
-
-enum ocla_trigger_condition { DEFAULT = 0, AND = 1, OR = 2, XOR = 3 };
+enum ocla_trigger_bool_comp { DEFAULT = 0, AND = 1, OR = 2, XOR = 3 };
 
 enum ocla_trigger_type {
   TRIGGER_NONE = 0,
@@ -54,17 +60,17 @@ enum ocla_trigger_event {
 };
 
 struct ocla_config {
-  ocla_mode mode;
-  ocla_trigger_condition condition;
-  ocla_fns fns;
+  ocla_trigger_mode mode;
+  ocla_trigger_bool_comp boolcomp;
+  bool fns;
   uint32_t ns;
-  uint32_t st;
 };
 
 struct ocla_trigger_config {
   ocla_trigger_type type;
   ocla_trigger_event event;
   uint32_t value;
+  uint32_t value_bitwidth;
   uint32_t probe_num;
 };
 
@@ -75,6 +81,13 @@ struct ocla_data {
   std::vector<uint32_t> values;
 };
 
+struct ocla_channel_register {
+  uint32_t tssr;
+  uint32_t tcur;
+  uint32_t tdcr;
+  uint32_t mask;
+};
+
 class OclaIP {
  public:
   OclaIP();
@@ -83,11 +96,14 @@ class OclaIP {
   void configure(ocla_config &cfg);
   void configure_channel(uint32_t channel, ocla_trigger_config &trig_cfg);
   void start();
+  void reset();
   ocla_config get_config() const;
   ocla_trigger_config get_channel_config(uint32_t channel) const;
   ocla_status get_status() const;
   uint32_t get_number_of_probes() const;
   uint32_t get_memory_depth() const;
+  uint32_t get_trigger_count() const;
+  uint32_t get_max_compare_value_size() const;
   uint32_t get_version() const;
   std::string get_type() const;
   uint32_t get_id() const;
@@ -95,10 +111,17 @@ class OclaIP {
   uint32_t get_base_addr() const { return m_base_addr; }
 
  private:
-  void configure_trigger(uint32_t addr, uint32_t offset,
-                         ocla_trigger_config &trig_cfg);
+  void read_registers();
   OclaJtagAdapter *m_adapter;
   uint32_t m_base_addr;
+  uint32_t m_type;
+  uint32_t m_version;
+  uint32_t m_id;
+  uint32_t m_uidp0;
+  uint32_t m_uidp1;
+  uint32_t m_ocsr;
+  uint32_t m_tmtr;
+  std::vector<ocla_channel_register> m_chregs;
 };
 
 #endif  //__OCLAIP_H__

--- a/src/ConfigurationRS/Ocla/OclaIP.h
+++ b/src/ConfigurationRS/Ocla/OclaIP.h
@@ -30,6 +30,71 @@
           // will be written to this register.  
 #define MASK (0x3C)  // [RW] Channel 1. For disjoint probe comparision
 
+// OCSR (OCLA Status Register) bitfield definitions
+#define OCSR_DA_Pos (0)
+#define OCSR_DA_Width (1)
+#define OCSR_DA_Msk (((1u << OCSR_DA_Width) - 1) << OCSR_DA_Pos)
+#define OCSR_TC_Pos (24)
+#define OCSR_TC_Width (5)
+#define OCSR_TC_Msk (((1u << OCSR_TC_Width) - 1) << OCSR_TC_Pos)
+#define OCSR_MCVS_Pos (29)
+#define OCSR_MCVS_Width (3)
+#define OCSR_MVCS_Msk (((1u << OCSR_MCVS_Width) - 1) << OCSR_MCVS_Pos)
+
+// UIDP0 (User IP Defined Param 0) bitfield definitions
+#define UIDP0_MD_Pos (0)
+#define UIDP0_MD_Width (15)
+#define UIDP0_MD_Msk (((1u << UIDP0_MD_Width) - 1) << UIDP0_MD_Pos)
+
+// UIDP1 (User IP Defined Param 1) bitfield definitions
+#define UIDP1_NP_Pos (0)
+#define UIDP1_NP_Width (15)
+#define UIDP1_NP_Msk (((1u << UIDP1_NP_Width) - 1) << UIDP1_NP_Pos)
+
+// TMTR (Trigger Mode Type Register) bitfield definitions
+#define TMTR_TM_Pos (0)
+#define TMTR_TM_Width (2)
+#define TMTR_TM_Msk (((1u << TMTR_TM_Width) - 1) << TMTR_TM_Pos)
+#define TMTR_B_Pos (2)
+#define TMTR_B_Width (2)
+#define TMTR_B_Msk (((1u << TMTR_B_Width) - 1) << TMTR_B_Pos)
+#define TMTR_FNS_Pos (4)
+#define TMTR_FNS_Width (1)
+#define TMTR_FNS_Msk (((1u << TMTR_FNS_Width) - 1) << TMTR_FNS_Pos)
+#define TMTR_NS_Pos (12)
+#define TMTR_NS_Width (20)
+#define TMTR_NS_Msk (((1u << TMTR_NS_Width) - 1) << TMTR_NS_Pos)
+
+// TSSR (Trigger Source Selection Register) bitfield definitions
+#define TSSR_PS_Pos (0)
+#define TSSR_PS_Width (10)
+#define TSSR_PS_Msk (((1u << TSSR_PS_Width) - 1) << TSSR_PS_Pos)
+#define TSSR_CW_Pos (24)
+#define TSSR_CW_Width (5)
+#define TSSR_CW_Msk (((1u << TSSR_CW_Width) - 1) << TSSR_CW_Pos)
+
+// TCUR (Trigger Control Unit Register) bitfield definitions
+#define TCUR_TT_Pos (0)
+#define TCUR_TT_Width (2)
+#define TCUR_TT_Msk (((1u << TCUR_TT_Width) - 1) << TCUR_TT_Pos)
+#define TCUR_ET_Pos (2)
+#define TCUR_ET_Width (2)
+#define TCUR_ET_Msk (((1u << TCUR_ET_Width) - 1) << TCUR_ET_Pos)
+#define TCUR_LT_Pos (4)
+#define TCUR_LT_Width (2)
+#define TCUR_LT_Msk (((1u << TCUR_LT_Width) - 1) << TCUR_LT_Pos)
+#define TCUR_VC_Pos (6)
+#define TCUR_VC_Width (2)
+#define TCUR_VC_Msk (((1u << TCUR_VC_Width) - 1) << TCUR_VC_Pos)
+
+// OCCR (OCLA Control Register) bitfield definitions
+#define OCCR_ST_Pos (0)
+#define OCCR_ST_Width (1)
+#define OCCR_ST_Msk (((1u << OCCR_ST_Width) - 1) << OCCR_ST_Pos)
+#define OCCR_SR_Pos (1)
+#define OCCR_SR_Width (1)
+#define OCCR_SR_Msk (((1u << OCCR_SR_Width) - 1) << OCCR_SR_Pos)
+
 class OclaJtagAdapter;
 
 enum ocla_status { NA = 0, DATA_AVAILABLE = 1 };

--- a/src/ConfigurationRS/Ocla/OclaIP.h
+++ b/src/ConfigurationRS/Ocla/OclaIP.h
@@ -135,7 +135,7 @@ struct ocla_trigger_config {
   ocla_trigger_type type;
   ocla_trigger_event event;
   uint32_t value;
-  uint32_t value_compare_width;
+  uint32_t compare_width;
   uint32_t probe_num;
 };
 

--- a/src/ConfigurationRS/Ocla/OclaIP.h
+++ b/src/ConfigurationRS/Ocla/OclaIP.h
@@ -101,7 +101,7 @@ enum ocla_status { NA = 0, DATA_AVAILABLE = 1 };
 
 enum ocla_trigger_mode { CONTINUOUS = 0, PRE = 1, POST = 2, CENTER = 3 };
 
-enum ocla_trigger_bool_comp { DEFAULT = 0, AND = 1, OR = 2, XOR = 3 };
+enum ocla_trigger_condition { DEFAULT = 0, AND = 1, OR = 2, XOR = 3 };
 
 enum ocla_trigger_type {
   TRIGGER_NONE = 0,
@@ -126,7 +126,7 @@ enum ocla_trigger_event {
 
 struct ocla_config {
   ocla_trigger_mode mode;
-  ocla_trigger_bool_comp boolcomp;
+  ocla_trigger_condition condition;
   bool enable_fix_sample_size;
   uint32_t sample_size;
 };

--- a/src/ConfigurationRS/Ocla/OclaIP.h
+++ b/src/ConfigurationRS/Ocla/OclaIP.h
@@ -135,7 +135,7 @@ struct ocla_trigger_config {
   ocla_trigger_type type;
   ocla_trigger_event event;
   uint32_t value;
-  uint32_t value_bitwidth;
+  uint32_t value_compare_width;
   uint32_t probe_num;
 };
 

--- a/src/ConfigurationRS/Ocla/OclaJtagAdapter.h
+++ b/src/ConfigurationRS/Ocla/OclaJtagAdapter.h
@@ -12,8 +12,8 @@ class OclaJtagAdapter {
   virtual ~OclaJtagAdapter(){};
   virtual void write(uint32_t addr, uint32_t data) = 0;
   virtual uint32_t read(uint32_t addr) = 0;
-  virtual std::vector<uint32_t> read(uint32_t base_addr, uint32_t num_reads,
-                                     uint32_t increase_by = 0) = 0;
+  virtual std::vector<std::tuple<uint32_t, uint32_t>> read(
+      uint32_t base_addr, uint32_t num_reads, uint32_t increase_by = 0) = 0;
   virtual void set_target_device(FOEDAG::Device device,
                                  std::vector<FOEDAG::Tap> taplist) = 0;
 };

--- a/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.cpp
+++ b/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.cpp
@@ -41,12 +41,11 @@ void OclaOpenocdAdapter::write(uint32_t addr, uint32_t data) {
 
 uint32_t OclaOpenocdAdapter::read(uint32_t addr) {
   auto values = read(addr, 1);
-  return values[0];
+  return std::get<1>(values[0]);
 }
 
-std::vector<uint32_t> OclaOpenocdAdapter::read(uint32_t base_addr,
-                                               uint32_t num_reads,
-                                               uint32_t increase_by) {
+std::vector<std::tuple<uint32_t, uint32_t>> OclaOpenocdAdapter::read(
+    uint32_t base_addr, uint32_t num_reads, uint32_t increase_by) {
   // ocla jtag read via openocd command
   // ----------------------------------
   // irscan ocla 0x04
@@ -66,14 +65,7 @@ std::vector<uint32_t> OclaOpenocdAdapter::read(uint32_t base_addr,
   auto values = parse(output);
   CFG_ASSERT_MSG(values.size() == num_reads,
                  "values size is not equal to read requests");
-
-  // todo: temporary convert to vector of uint32_t
-  std::vector<uint32_t> tmp;
-  for (auto &elmt : values) {
-    tmp.push_back(std::get<1>(elmt));
-  }
-  return tmp;
-  // return values;
+  return values;
 }
 
 std::string OclaOpenocdAdapter::build_tcl_proc(uint32_t tap_index) {

--- a/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.cpp
+++ b/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.cpp
@@ -26,13 +26,6 @@ void OclaOpenocdAdapter::write(uint32_t addr, uint32_t data) {
   std::stringstream ss;
   uint32_t i = m_device.tap.index;
 
-  // ss << " -c \"irscan tap" << i << ".tap 0x04;"
-  //    << "drscan tap" << i << ".tap 1 0x1 1 0x1 32 " << std::hex <<
-  //    std::showbase
-  //    << addr << " 32 " << data << " 2 0x0;" << std::dec << std::noshowbase
-  //    << "irscan tap" << i << ".tap 0x08;"
-  //    << "drscan tap" << i << ".tap 32 0x0 2 0x0;\"";
-
   ss << " -c \"set addr [format 0x%08x " << addr << "];"
      << "set data [format 0x%08x " << data << "];"
      << "irscan tap" << i << ".tap 0x04;"
@@ -63,16 +56,6 @@ std::vector<uint32_t> OclaOpenocdAdapter::read(uint32_t base_addr,
 
   std::string output;
   std::stringstream ss;
-  // uint32_t j = m_device.tap.index;
-
-  // for (uint32_t i = 0; i < num_reads; i++) {
-  //   ss << " -c \"irscan tap" << j << ".tap 0x04;"
-  //      << "drscan tap" << j << ".tap 1 0x1 1 0x0 32 " << std::hex
-  //      << std::showbase << base_addr << " 32 0x0 2 0x0;" << std::dec
-  //      << std::noshowbase << "irscan tap" << j << ".tap 0x08;"
-  //      << "drscan tap" << j << ".tap 32 0x0 2 0x0;\"";
-  //   base_addr += increase_by;
-  // }
 
   ss << build_tcl_proc(m_device.index) << " -c \"ocla_read " << std::hex
      << std::showbase << base_addr << std::dec << std::noshowbase << " "
@@ -90,7 +73,6 @@ std::vector<uint32_t> OclaOpenocdAdapter::read(uint32_t base_addr,
     tmp.push_back(std::get<1>(elmt));
   }
   return tmp;
-
   // return values;
 }
 
@@ -139,7 +121,6 @@ std::vector<std::tuple<uint32_t, uint32_t>> OclaOpenocdAdapter::parse(
             std::regex("^0x([0-9A-F]{8}) ([0-9A-F]{8}) ([0-9A-F]{2})$",
                        std::regex::icase)) == true) {
       CFG_ASSERT_MSG(stoi(matches[3], nullptr, 16) == 0, "ocla error");
-      // values.push_back((uint32_t)stoul(matches[2], nullptr, 16));
       values.push_back(
           std::make_tuple((uint32_t)stoul(matches[1], nullptr, 16),
                           (uint32_t)stoul(matches[2], nullptr, 16)));

--- a/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.h
+++ b/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <iostream>
+#include <tuple>
 
 #include "Configuration/HardwareManager/OpenocdAdapter.h"
 #include "OclaJtagAdapter.h"
@@ -23,7 +24,8 @@ class OclaOpenocdAdapter : public OclaJtagAdapter,
 
  private:
   int execute_command(const std::string& cmd, std::string& output);
-  std::vector<uint32_t> parse(const std::string& output);
+  std::string build_tcl_proc(uint32_t tap_num);
+  std::vector<std::tuple<uint32_t, uint32_t>> parse(const std::string& output);
   std::string m_openocd;
   FOEDAG::Device m_device;
   std::vector<FOEDAG::Tap> m_taplist;

--- a/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.h
+++ b/src/ConfigurationRS/Ocla/OclaOpenocdAdapter.h
@@ -17,8 +17,8 @@ class OclaOpenocdAdapter : public OclaJtagAdapter,
   virtual ~OclaOpenocdAdapter();
   virtual void write(uint32_t addr, uint32_t data);
   virtual uint32_t read(uint32_t addr);
-  virtual std::vector<uint32_t> read(uint32_t base_addr, uint32_t num_reads,
-                                     uint32_t increase_by = 0);
+  virtual std::vector<std::tuple<uint32_t, uint32_t>> read(
+      uint32_t base_addr, uint32_t num_reads, uint32_t increase_by = 0);
   virtual void set_target_device(FOEDAG::Device device,
                                  std::vector<FOEDAG::Tap> taplist);
 

--- a/src/ConfigurationRS/Ocla/Ocla_entry.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla_entry.cpp
@@ -77,7 +77,7 @@ void Ocla_entry(CFGCommon_ARG* cmdarg) {
       return;
     }
     adapter.set_target_device(device, taplist);
-    ocla.configure(parms->instance, parms->mode, parms->trigger_condition,
+    ocla.configure(parms->instance, parms->mode, parms->multi_trigger_bool,
                    parms->sample_size);
   } else if (subcmd == "config_channel") {
     auto parms =
@@ -101,7 +101,8 @@ void Ocla_entry(CFGCommon_ARG* cmdarg) {
     }
     adapter.set_target_device(device, taplist);
     ocla.configure_channel(parms->instance, parms->channel, parms->type,
-                           parms->event, parms->value, parms->probe);
+                           parms->event, parms->value,
+                           parms->value_compare_width, parms->probe);
   } else if (subcmd == "start") {
     auto parms = static_cast<const CFGArg_DEBUGGER_START*>(arg->get_sub_arg());
     if (parms->instance == 0 || parms->instance > 2) {

--- a/src/ConfigurationRS/Ocla/Ocla_entry.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla_entry.cpp
@@ -77,7 +77,7 @@ void Ocla_entry(CFGCommon_ARG* cmdarg) {
       return;
     }
     adapter.set_target_device(device, taplist);
-    ocla.configure(parms->instance, parms->mode, parms->multi_trigger_bool,
+    ocla.configure(parms->instance, parms->mode, parms->trigger_condition,
                    parms->sample_size);
   } else if (subcmd == "config_channel") {
     auto parms =
@@ -101,8 +101,8 @@ void Ocla_entry(CFGCommon_ARG* cmdarg) {
     }
     adapter.set_target_device(device, taplist);
     ocla.configure_channel(parms->instance, parms->channel, parms->type,
-                           parms->event, parms->value,
-                           parms->value_compare_width, parms->probe);
+                           parms->event, parms->value, parms->compare_width,
+                           parms->probe);
   } else if (subcmd == "start") {
     auto parms = static_cast<const CFGArg_DEBUGGER_START*>(arg->get_sub_arg());
     if (parms->instance == 0 || parms->instance > 2) {

--- a/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
@@ -27,29 +27,29 @@ INSTANTIATE_TEST_SUITE_P(
 
 class ConvertTriggerConditionToStringParamTest
     : public ::testing::TestWithParam<
-          std::pair<ocla_trigger_bool_comp, std::string>> {};
+          std::pair<ocla_trigger_condition, std::string>> {};
 
 TEST_P(ConvertTriggerConditionToStringParamTest, ConvertTriggerCondition) {
   const auto& param = GetParam();
-  const ocla_trigger_bool_comp condition = param.first;
+  const ocla_trigger_condition condition = param.first;
   const std::string& expected_result = param.second;
 
-  std::string result = convert_trigger_bool_comp_to_string(condition);
+  std::string result = convert_trigger_condition_to_string(condition);
   EXPECT_EQ(result, expected_result);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     Default, ConvertTriggerConditionToStringParamTest,
-    ::testing::Values(std::make_pair(ocla_trigger_bool_comp::OR, "OR"),
-                      std::make_pair(ocla_trigger_bool_comp::AND, "AND"),
-                      std::make_pair(ocla_trigger_bool_comp::DEFAULT, "OR"),
-                      std::make_pair(ocla_trigger_bool_comp(99), "(unknown)"),
-                      std::make_pair(ocla_trigger_bool_comp::XOR, "XOR")));
+    ::testing::Values(std::make_pair(ocla_trigger_condition::OR, "OR"),
+                      std::make_pair(ocla_trigger_condition::AND, "AND"),
+                      std::make_pair(ocla_trigger_condition::DEFAULT, "OR"),
+                      std::make_pair(ocla_trigger_condition(99), "(unknown)"),
+                      std::make_pair(ocla_trigger_condition::XOR, "XOR")));
 
-TEST(convert_trigger_bool_comp_to_string, DefaultModeString) {
+TEST(convert_trigger_condition_to_string, DefaultModeString) {
   // Test converting with a default value
   auto result =
-      convert_trigger_bool_comp_to_string((ocla_trigger_bool_comp)10, "AND");
+      convert_trigger_condition_to_string((ocla_trigger_condition)10, "AND");
   EXPECT_EQ(result, "AND");
 }
 
@@ -132,7 +132,7 @@ TEST(ConvertOclaModeTest, DefaultModeString) {
 
 struct TestParam {
   std::string condition_string;
-  ocla_trigger_bool_comp expected_result;
+  ocla_trigger_condition expected_result;
 };
 
 class ConvertTriggerConditionTest : public ::testing::TestWithParam<TestParam> {
@@ -141,17 +141,17 @@ class ConvertTriggerConditionTest : public ::testing::TestWithParam<TestParam> {
 TEST_P(ConvertTriggerConditionTest, ConvertTriggerCondition) {
   const auto& param = GetParam();
   const std::string condition = param.condition_string;
-  const ocla_trigger_bool_comp expected_result = param.expected_result;
+  const ocla_trigger_condition expected_result = param.expected_result;
 
-  ocla_trigger_bool_comp result = convert_trigger_bool_comp(condition);
+  ocla_trigger_condition result = convert_trigger_condition(condition);
   EXPECT_EQ(result, expected_result);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     Default, ConvertTriggerConditionTest,
-    ::testing::Values(TestParam{"OR", ocla_trigger_bool_comp::DEFAULT},
-                      TestParam{"AND", ocla_trigger_bool_comp::AND},
-                      TestParam{"XOR", ocla_trigger_bool_comp::XOR}));
+    ::testing::Values(TestParam{"OR", ocla_trigger_condition::DEFAULT},
+                      TestParam{"AND", ocla_trigger_condition::AND},
+                      TestParam{"XOR", ocla_trigger_condition::XOR}));
 
 TEST(ConvertTriggerTypeTest, ValidTriggerType) {
   std::vector<std::pair<ocla_trigger_type, std::string>> testParam{

--- a/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
@@ -5,50 +5,51 @@
 #include "OclaHelpers.h"
 
 class ConvertOclaModeToStringParamTest
-    : public ::testing::TestWithParam<std::pair<ocla_mode, std::string>> {};
+    : public ::testing::TestWithParam<
+          std::pair<ocla_trigger_mode, std::string>> {};
 
 TEST_P(ConvertOclaModeToStringParamTest, ConvertOclaMode) {
   const auto& param = GetParam();
-  const ocla_mode mode = param.first;
+  const ocla_trigger_mode mode = param.first;
   const std::string& expected_result = param.second;
 
-  std::string result = convert_ocla_mode_to_string(mode);
+  std::string result = convert_ocla_trigger_mode_to_string(mode);
   EXPECT_EQ(result, expected_result);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     Default, ConvertOclaModeToStringParamTest,
-    ::testing::Values(std::make_pair(NO_TRIGGER, "disable"),
+    ::testing::Values(std::make_pair(CONTINUOUS, "disable"),
                       std::make_pair(PRE, "pre-trigger"),
                       std::make_pair(POST, "post-trigger"),
                       std::make_pair(CENTER, "center-trigger"),
-                      std::make_pair(NO_TRIGGER, "disable")));
+                      std::make_pair(CONTINUOUS, "disable")));
 
 class ConvertTriggerConditionToStringParamTest
     : public ::testing::TestWithParam<
-          std::pair<ocla_trigger_condition, std::string>> {};
+          std::pair<ocla_trigger_bool_comp, std::string>> {};
 
 TEST_P(ConvertTriggerConditionToStringParamTest, ConvertTriggerCondition) {
   const auto& param = GetParam();
-  const ocla_trigger_condition condition = param.first;
+  const ocla_trigger_bool_comp condition = param.first;
   const std::string& expected_result = param.second;
 
-  std::string result = convert_trigger_condition_to_string(condition);
+  std::string result = convert_trigger_bool_comp_to_string(condition);
   EXPECT_EQ(result, expected_result);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     Default, ConvertTriggerConditionToStringParamTest,
-    ::testing::Values(std::make_pair(ocla_trigger_condition::OR, "OR"),
-                      std::make_pair(ocla_trigger_condition::AND, "AND"),
-                      std::make_pair(ocla_trigger_condition::DEFAULT, "OR"),
-                      std::make_pair(ocla_trigger_condition(99), "(unknown)"),
-                      std::make_pair(ocla_trigger_condition::XOR, "XOR")));
+    ::testing::Values(std::make_pair(ocla_trigger_bool_comp::OR, "OR"),
+                      std::make_pair(ocla_trigger_bool_comp::AND, "AND"),
+                      std::make_pair(ocla_trigger_bool_comp::DEFAULT, "OR"),
+                      std::make_pair(ocla_trigger_bool_comp(99), "(unknown)"),
+                      std::make_pair(ocla_trigger_bool_comp::XOR, "XOR")));
 
-TEST(convert_trigger_condition_to_string, DefaultModeString) {
+TEST(convert_trigger_bool_comp_to_string, DefaultModeString) {
   // Test converting with a default value
   auto result =
-      convert_trigger_condition_to_string((ocla_trigger_condition)10, "AND");
+      convert_trigger_bool_comp_to_string((ocla_trigger_bool_comp)10, "AND");
   EXPECT_EQ(result, "AND");
 }
 
@@ -103,14 +104,15 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_pair(ocla_trigger_event(99), "(unknown)")));
 
 class ConvertOclaModeParamTest
-    : public ::testing::TestWithParam<std::pair<std::string, ocla_mode>> {};
+    : public ::testing::TestWithParam<
+          std::pair<std::string, ocla_trigger_mode>> {};
 
 TEST_P(ConvertOclaModeParamTest, ConvertModeString) {
   const auto& param = GetParam();
   const std::string& mode_string = param.first;
-  ocla_mode expected_result = param.second;
+  ocla_trigger_mode expected_result = param.second;
 
-  ocla_mode result = convert_ocla_mode(mode_string);
+  ocla_trigger_mode result = convert_ocla_trigger_mode(mode_string);
   EXPECT_EQ(result, expected_result);
 }
 
@@ -118,19 +120,19 @@ INSTANTIATE_TEST_SUITE_P(
     Default, ConvertOclaModeParamTest,
     ::testing::Values(std::make_pair("pre-trigger", PRE),
                       std::make_pair("post-trigger", POST),
-                      std::make_pair("disable", NO_TRIGGER),
+                      std::make_pair("disable", CONTINUOUS),
                       std::make_pair("post-trigger", POST),
-                      std::make_pair("invalid-mode", NO_TRIGGER)));
+                      std::make_pair("invalid-mode", CONTINUOUS)));
 
 TEST(ConvertOclaModeTest, DefaultModeString) {
   // Test converting with a default value
-  ocla_mode result = convert_ocla_mode("invalid-mode", POST);
+  ocla_trigger_mode result = convert_ocla_trigger_mode("invalid-mode", POST);
   EXPECT_EQ(result, POST);
 }
 
 struct TestParam {
   std::string condition_string;
-  ocla_trigger_condition expected_result;
+  ocla_trigger_bool_comp expected_result;
 };
 
 class ConvertTriggerConditionTest : public ::testing::TestWithParam<TestParam> {
@@ -139,17 +141,17 @@ class ConvertTriggerConditionTest : public ::testing::TestWithParam<TestParam> {
 TEST_P(ConvertTriggerConditionTest, ConvertTriggerCondition) {
   const auto& param = GetParam();
   const std::string condition = param.condition_string;
-  const ocla_trigger_condition expected_result = param.expected_result;
+  const ocla_trigger_bool_comp expected_result = param.expected_result;
 
-  ocla_trigger_condition result = convert_trigger_condition(condition);
+  ocla_trigger_bool_comp result = convert_trigger_bool_comp(condition);
   EXPECT_EQ(result, expected_result);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     Default, ConvertTriggerConditionTest,
-    ::testing::Values(TestParam{"OR", ocla_trigger_condition::DEFAULT},
-                      TestParam{"AND", ocla_trigger_condition::AND},
-                      TestParam{"XOR", ocla_trigger_condition::XOR}));
+    ::testing::Values(TestParam{"OR", ocla_trigger_bool_comp::DEFAULT},
+                      TestParam{"AND", ocla_trigger_bool_comp::AND},
+                      TestParam{"XOR", ocla_trigger_bool_comp::XOR}));
 
 TEST(ConvertTriggerTypeTest, ValidTriggerType) {
   std::vector<std::pair<ocla_trigger_type, std::string>> testParam{

--- a/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <memory>
+#include <tuple>
 
 #include "OclaIP.h"
 #include "OclaJtagAdapter.h"
@@ -15,7 +16,7 @@ class MockOclaJtagAdapter : public OclaJtagAdapter {
  public:
   MOCK_METHOD(void, write, (uint32_t addr, uint32_t data), (override));
   MOCK_METHOD(uint32_t, read, (uint32_t addr), (override));
-  MOCK_METHOD(std::vector<uint32_t>, read,
+  MOCK_METHOD((std::vector<std::tuple<uint32_t, uint32_t>>), read,
               (uint32_t base_addr, uint32_t num_reads, uint32_t increase_by),
               (override));
   MOCK_METHOD(void, set_target_device,
@@ -192,7 +193,8 @@ TEST_F(OclaIPTest, getDataTest_FixSampleSize) {
   ON_CALL(mockAdapter, read(UIDP1)).WillByDefault(Return(33));
   EXPECT_CALL(mockAdapter, read(TBDR, 256, 0))
       .Times(1)
-      .WillOnce(Return(std::vector<uint32_t>(256, 0)));
+      .WillOnce(Return(std::vector<std::tuple<uint32_t, uint32_t>>(
+          256, std::make_tuple(0, 0))));
 
   OclaIP oclaIP(&mockAdapter, 0);
   auto result = oclaIP.get_data();
@@ -215,7 +217,8 @@ TEST_F(OclaIPTest, getDataTest_End2End) {
 
   EXPECT_CALL(mockAdapter, read(TBDR, 988 * 3, 0))
       .Times(1)
-      .WillOnce(Return(std::vector<uint32_t>(988 * 3, 0)));
+      .WillOnce(Return(std::vector<std::tuple<uint32_t, uint32_t>>{
+          988 * 3, std::make_tuple(0, 0)}));
 
   OclaIP oclaIP(&mockAdapter, 0);
   oclaIP.configure(cfg);

--- a/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
@@ -98,7 +98,7 @@ TEST_F(OclaIPTest, getVersionTest) {
 
 TEST_F(OclaIPTest, configureTest) {
   ocla_config cfg;
-  cfg.boolcomp = ocla_trigger_bool_comp::XOR;
+  cfg.condition = ocla_trigger_condition::XOR;
   cfg.mode = ocla_trigger_mode::PRE;
   cfg.enable_fix_sample_size = true;
   cfg.sample_size = 1234;
@@ -208,7 +208,7 @@ TEST_F(OclaIPTest, getDataTest_End2End) {
 
   ocla_config cfg;
 
-  cfg.boolcomp = ocla_trigger_bool_comp::OR;
+  cfg.condition = ocla_trigger_condition::OR;
   cfg.mode = ocla_trigger_mode::POST;
   cfg.enable_fix_sample_size = true;
   cfg.sample_size = 988;
@@ -252,7 +252,7 @@ TEST_F(OclaIPTest, getDataTest_ConfigReadback) {
 TEST_F(OclaIPTest, getConfigTest_default) {
   OclaIP oclaIP(&mockAdapter, 0);
   ocla_config configData = oclaIP.get_config();
-  EXPECT_EQ(ocla_trigger_bool_comp::DEFAULT, configData.boolcomp);
+  EXPECT_EQ(ocla_trigger_condition::DEFAULT, configData.condition);
   EXPECT_EQ(ocla_trigger_mode::CONTINUOUS, configData.mode);
   EXPECT_EQ(false, configData.enable_fix_sample_size);
   EXPECT_EQ(1, configData.sample_size);
@@ -262,7 +262,7 @@ TEST_F(OclaIPTest, getConfigTest) {
   ON_CALL(mockAdapter, read(TMTR)).WillByDefault(Return(0x59ac5599));
   OclaIP oclaIP(&mockAdapter, 0);
   ocla_config configData = oclaIP.get_config();
-  EXPECT_EQ(ocla_trigger_bool_comp::OR, configData.boolcomp);
+  EXPECT_EQ(ocla_trigger_condition::OR, configData.condition);
   EXPECT_EQ(ocla_trigger_mode::PRE, configData.mode);
   EXPECT_EQ(true, configData.enable_fix_sample_size);
   EXPECT_EQ(367302, configData.sample_size);

--- a/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
@@ -118,7 +118,7 @@ TEST_F(OclaIPTest, configureChannelTest_Edge) {
   cfg.type = ocla_trigger_type::EDGE;
   cfg.event = ocla_trigger_event::RISING;
   cfg.probe_num = 7;
-  cfg.value_compare_width = 0;
+  cfg.compare_width = 0;
   cfg.value = 0;
 
   EXPECT_CALL(mockAdapter, write(TSSR + 0x90, 7)).Times(1);
@@ -140,7 +140,7 @@ TEST_F(OclaIPTest, configureChannelTest_Level) {
   cfg.type = ocla_trigger_type::LEVEL;
   cfg.event = ocla_trigger_event::LOW;
   cfg.probe_num = 999;
-  cfg.value_compare_width = 0;
+  cfg.compare_width = 0;
   cfg.value = 0;
 
   EXPECT_CALL(mockAdapter, write(TSSR + 0x30, 999)).Times(1);
@@ -162,7 +162,7 @@ TEST_F(OclaIPTest, configureChannelTest_ValueCompare) {
   cfg.type = ocla_trigger_type::VALUE_COMPARE;
   cfg.event = ocla_trigger_event::EQUAL;
   cfg.probe_num = 21;
-  cfg.value_compare_width = 12;
+  cfg.compare_width = 12;
   cfg.value = 1234;
 
   EXPECT_CALL(mockAdapter, write(TSSR + 0x60, (11u << 24) + 21)).Times(1);
@@ -237,7 +237,7 @@ TEST_F(OclaIPTest, getDataTest_ConfigReadback) {
   cfg.event = ocla_trigger_event::EQUAL;
   cfg.probe_num = 17;
   cfg.value = 123;
-  cfg.value_compare_width = 12;
+  cfg.compare_width = 12;
 
   OclaIP oclaIP(&mockAdapter, 0);
   oclaIP.configure_channel(5, cfg);
@@ -246,7 +246,7 @@ TEST_F(OclaIPTest, getDataTest_ConfigReadback) {
   EXPECT_EQ(cfg.event, result.event);
   EXPECT_EQ(cfg.probe_num, result.probe_num);
   EXPECT_EQ(cfg.value, result.value);
-  EXPECT_EQ(cfg.value_compare_width, result.value_compare_width);
+  EXPECT_EQ(cfg.compare_width, result.compare_width);
 }
 
 TEST_F(OclaIPTest, getConfigTest_default) {
@@ -279,7 +279,7 @@ TEST_F(OclaIPTest, getChannelConfigTest_Edge) {
   EXPECT_EQ(ocla_trigger_event::FALLING, configData.event);
   EXPECT_EQ(999, configData.probe_num);
   EXPECT_EQ(0, configData.value);
-  EXPECT_EQ(0, configData.value_compare_width);
+  EXPECT_EQ(0, configData.compare_width);
 }
 
 TEST_F(OclaIPTest, getChannelConfigTest_Level) {
@@ -293,7 +293,7 @@ TEST_F(OclaIPTest, getChannelConfigTest_Level) {
   EXPECT_EQ(ocla_trigger_event::HIGH, configData.event);
   EXPECT_EQ(123, configData.probe_num);
   EXPECT_EQ(0, configData.value);
-  EXPECT_EQ(0, configData.value_compare_width);
+  EXPECT_EQ(0, configData.compare_width);
 }
 
 TEST_F(OclaIPTest, getChannelConfigTest_ValueCompare) {
@@ -309,7 +309,7 @@ TEST_F(OclaIPTest, getChannelConfigTest_ValueCompare) {
   EXPECT_EQ(ocla_trigger_event::EQUAL, configData.event);
   EXPECT_EQ(123, configData.probe_num);
   EXPECT_EQ(99, configData.value);
-  EXPECT_EQ(8, configData.value_compare_width);
+  EXPECT_EQ(8, configData.compare_width);
 }
 
 TEST_F(OclaIPTest, getChannelConfigTest_default) {
@@ -319,5 +319,5 @@ TEST_F(OclaIPTest, getChannelConfigTest_default) {
   EXPECT_EQ(ocla_trigger_event::NONE, configData.event);
   EXPECT_EQ(0, configData.probe_num);
   EXPECT_EQ(0, configData.value);
-  EXPECT_EQ(0, configData.value_compare_width);
+  EXPECT_EQ(0, configData.compare_width);
 }

--- a/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
@@ -118,7 +118,7 @@ TEST_F(OclaIPTest, configureChannelTest_Edge) {
   cfg.type = ocla_trigger_type::EDGE;
   cfg.event = ocla_trigger_event::RISING;
   cfg.probe_num = 7;
-  cfg.value_bitwidth = 0;
+  cfg.value_compare_width = 0;
   cfg.value = 0;
 
   EXPECT_CALL(mockAdapter, write(TSSR + 0x90, 7)).Times(1);
@@ -140,7 +140,7 @@ TEST_F(OclaIPTest, configureChannelTest_Level) {
   cfg.type = ocla_trigger_type::LEVEL;
   cfg.event = ocla_trigger_event::LOW;
   cfg.probe_num = 999;
-  cfg.value_bitwidth = 0;
+  cfg.value_compare_width = 0;
   cfg.value = 0;
 
   EXPECT_CALL(mockAdapter, write(TSSR + 0x30, 999)).Times(1);
@@ -162,7 +162,7 @@ TEST_F(OclaIPTest, configureChannelTest_ValueCompare) {
   cfg.type = ocla_trigger_type::VALUE_COMPARE;
   cfg.event = ocla_trigger_event::EQUAL;
   cfg.probe_num = 21;
-  cfg.value_bitwidth = 12;
+  cfg.value_compare_width = 12;
   cfg.value = 1234;
 
   EXPECT_CALL(mockAdapter, write(TSSR + 0x60, (11u << 24) + 21)).Times(1);
@@ -237,7 +237,7 @@ TEST_F(OclaIPTest, getDataTest_ConfigReadback) {
   cfg.event = ocla_trigger_event::EQUAL;
   cfg.probe_num = 17;
   cfg.value = 123;
-  cfg.value_bitwidth = 12;
+  cfg.value_compare_width = 12;
 
   OclaIP oclaIP(&mockAdapter, 0);
   oclaIP.configure_channel(5, cfg);
@@ -246,7 +246,7 @@ TEST_F(OclaIPTest, getDataTest_ConfigReadback) {
   EXPECT_EQ(cfg.event, result.event);
   EXPECT_EQ(cfg.probe_num, result.probe_num);
   EXPECT_EQ(cfg.value, result.value);
-  EXPECT_EQ(cfg.value_bitwidth, result.value_bitwidth);
+  EXPECT_EQ(cfg.value_compare_width, result.value_compare_width);
 }
 
 TEST_F(OclaIPTest, getConfigTest_default) {
@@ -279,7 +279,7 @@ TEST_F(OclaIPTest, getChannelConfigTest_Edge) {
   EXPECT_EQ(ocla_trigger_event::FALLING, configData.event);
   EXPECT_EQ(999, configData.probe_num);
   EXPECT_EQ(0, configData.value);
-  EXPECT_EQ(0, configData.value_bitwidth);
+  EXPECT_EQ(0, configData.value_compare_width);
 }
 
 TEST_F(OclaIPTest, getChannelConfigTest_Level) {
@@ -293,7 +293,7 @@ TEST_F(OclaIPTest, getChannelConfigTest_Level) {
   EXPECT_EQ(ocla_trigger_event::HIGH, configData.event);
   EXPECT_EQ(123, configData.probe_num);
   EXPECT_EQ(0, configData.value);
-  EXPECT_EQ(0, configData.value_bitwidth);
+  EXPECT_EQ(0, configData.value_compare_width);
 }
 
 TEST_F(OclaIPTest, getChannelConfigTest_ValueCompare) {
@@ -309,7 +309,7 @@ TEST_F(OclaIPTest, getChannelConfigTest_ValueCompare) {
   EXPECT_EQ(ocla_trigger_event::EQUAL, configData.event);
   EXPECT_EQ(123, configData.probe_num);
   EXPECT_EQ(99, configData.value);
-  EXPECT_EQ(8, configData.value_bitwidth);
+  EXPECT_EQ(8, configData.value_compare_width);
 }
 
 TEST_F(OclaIPTest, getChannelConfigTest_default) {
@@ -319,5 +319,5 @@ TEST_F(OclaIPTest, getChannelConfigTest_default) {
   EXPECT_EQ(ocla_trigger_event::NONE, configData.event);
   EXPECT_EQ(0, configData.probe_num);
   EXPECT_EQ(0, configData.value);
-  EXPECT_EQ(0, configData.value_bitwidth);
+  EXPECT_EQ(0, configData.value_compare_width);
 }

--- a/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
@@ -100,8 +100,8 @@ TEST_F(OclaIPTest, configureTest) {
   ocla_config cfg;
   cfg.boolcomp = ocla_trigger_bool_comp::XOR;
   cfg.mode = ocla_trigger_mode::PRE;
-  cfg.fns = true;
-  cfg.ns = 1234;
+  cfg.enable_fix_sample_size = true;
+  cfg.sample_size = 1234;
   EXPECT_CALL(mockAdapter, write(TMTR, 0x4d101d));
   OclaIP oclaIP(&mockAdapter, 0);
   oclaIP.configure(cfg);
@@ -210,8 +210,8 @@ TEST_F(OclaIPTest, getDataTest_End2End) {
 
   cfg.boolcomp = ocla_trigger_bool_comp::OR;
   cfg.mode = ocla_trigger_mode::POST;
-  cfg.fns = true;
-  cfg.ns = 988;
+  cfg.enable_fix_sample_size = true;
+  cfg.sample_size = 988;
 
   EXPECT_CALL(mockAdapter, read(TBDR, 988 * 3, 0))
       .Times(1)
@@ -254,8 +254,8 @@ TEST_F(OclaIPTest, getConfigTest_default) {
   ocla_config configData = oclaIP.get_config();
   EXPECT_EQ(ocla_trigger_bool_comp::DEFAULT, configData.boolcomp);
   EXPECT_EQ(ocla_trigger_mode::CONTINUOUS, configData.mode);
-  EXPECT_EQ(false, configData.fns);
-  EXPECT_EQ(1, configData.ns);
+  EXPECT_EQ(false, configData.enable_fix_sample_size);
+  EXPECT_EQ(1, configData.sample_size);
 }
 
 TEST_F(OclaIPTest, getConfigTest) {
@@ -264,8 +264,8 @@ TEST_F(OclaIPTest, getConfigTest) {
   ocla_config configData = oclaIP.get_config();
   EXPECT_EQ(ocla_trigger_bool_comp::OR, configData.boolcomp);
   EXPECT_EQ(ocla_trigger_mode::PRE, configData.mode);
-  EXPECT_EQ(true, configData.fns);
-  EXPECT_EQ(367302, configData.ns);
+  EXPECT_EQ(true, configData.enable_fix_sample_size);
+  EXPECT_EQ(367302, configData.sample_size);
 }
 
 TEST_F(OclaIPTest, getChannelConfigTest_Edge) {

--- a/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaIpTests.cpp
@@ -8,6 +8,7 @@
 #include "OclaJtagAdapter.h"
 
 using ::testing::_;
+using ::testing::NiceMock;
 using ::testing::Return;
 
 class MockOclaJtagAdapter : public OclaJtagAdapter {
@@ -24,187 +25,299 @@ class MockOclaJtagAdapter : public OclaJtagAdapter {
 
 class OclaIPTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    baseAddr = 0;
-    oclaIP = std::make_shared<OclaIP>(&mockAdapter, baseAddr);
-  }
+  void SetUp() override {}
 
   void TearDown() override {}
 
-  std::shared_ptr<OclaIP> oclaIP;
-  uint32_t baseAddr;
-  MockOclaJtagAdapter mockAdapter;
+  NiceMock<MockOclaJtagAdapter> mockAdapter;
 };
 
-TEST_F(OclaIPTest, getStatusTest) {
-  EXPECT_CALL(mockAdapter, read(baseAddr + OCSR)).WillOnce(Return(1));
-  auto result = oclaIP->get_status();
+TEST_F(OclaIPTest, getStatusTest_DataAvailable) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(0x12340000 + 1));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_status();
   ASSERT_EQ(result, DATA_AVAILABLE);
 }
 
+TEST_F(OclaIPTest, getStatusTest_DataNotAvailable) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(0x12340000 + 0));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_status();
+  ASSERT_EQ(result, NA);
+}
+
 TEST_F(OclaIPTest, getNumberOfProbesTest) {
-  const uint32_t rawNumberOfProbes = 33;
-  EXPECT_CALL(mockAdapter, read(baseAddr + OCSR))
-      .WillOnce(Return(rawNumberOfProbes));
-  auto expectedNumProbes = (rawNumberOfProbes >> 1) & 0x3ff;
-  auto result = oclaIP->get_number_of_probes();
-  ASSERT_EQ(expectedNumProbes, result);
+  ON_CALL(mockAdapter, read(UIDP1)).WillByDefault(Return(0xffff0000 + 333));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_number_of_probes();
+  ASSERT_EQ(333, result);
 }
 
 TEST_F(OclaIPTest, getMemoryDepthTest) {
-  const uint32_t memoryDepth = 0xffff0000;
-  EXPECT_CALL(mockAdapter, read(baseAddr + OCSR)).WillOnce(Return(memoryDepth));
-  const uint32_t expectedMemoryDepth = (memoryDepth >> 11) & 0x3ff;
-  auto result = oclaIP->get_memory_depth();
-  ASSERT_EQ(expectedMemoryDepth, result);
+  ON_CALL(mockAdapter, read(UIDP0)).WillByDefault(Return(0xffff0000 + 444));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_memory_depth();
+  ASSERT_EQ(444, result);
+}
+
+TEST_F(OclaIPTest, getTriggerCountTest) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(((15u << 24) + 0x123)));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_trigger_count();
+  ASSERT_EQ(16, result);
+}
+
+TEST_F(OclaIPTest, getMaxCompareValueSizeTest) {
+  ON_CALL(mockAdapter, read(OCSR))
+      .WillByDefault(Return(((1u << 29) + 0x34123)));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_max_compare_value_size();
+  ASSERT_EQ(64, result);
 }
 
 TEST_F(OclaIPTest, getIdTest) {
-  const uint32_t expectedId = 42;
-  EXPECT_CALL(mockAdapter, read(baseAddr + IP_ID)).WillOnce(Return(expectedId));
-  auto result = oclaIP->get_id();
-  ASSERT_EQ(expectedId, result);
+  ON_CALL(mockAdapter, read(IP_ID)).WillByDefault(Return(1234));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_id();
+  ASSERT_EQ(1234, result);
 }
 
 TEST_F(OclaIPTest, getTypeTest) {
-  const uint32_t expectedTypeUint32 = 0x6F636C61;
-  const std::string expectedType = "ocla";
-  EXPECT_CALL(mockAdapter, read(baseAddr + IP_TYPE))
-      .WillOnce(Return(expectedTypeUint32));
-  auto result = oclaIP->get_type();
-  ASSERT_EQ(expectedType, result);
+  ON_CALL(mockAdapter, read(IP_TYPE)).WillByDefault(Return(0x41424344));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_type();
+  ASSERT_EQ("ABCD", result);
 }
 
 TEST_F(OclaIPTest, getVersionTest) {
-  const uint32_t expectedVersion = 1234;
-  EXPECT_CALL(mockAdapter, read(baseAddr + IP_VERSION))
-      .WillOnce(Return(expectedVersion));
-  auto result = oclaIP->get_version();
-  ASSERT_EQ(expectedVersion, result);
+  ON_CALL(mockAdapter, read(IP_VERSION)).WillByDefault(Return(123456789));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_version();
+  ASSERT_EQ(123456789, result);
 }
 
 TEST_F(OclaIPTest, configureTest) {
   ocla_config cfg;
-  cfg.fns = ocla_fns::ENABLED;
-  cfg.ns = 1000;
-  cfg.mode = ocla_mode::PRE;
-  cfg.condition = ocla_trigger_condition::DEFAULT;
-
-  uint32_t tmtr = 0x3E89;
-  EXPECT_CALL(mockAdapter, write(baseAddr + TMTR, tmtr));
-
-  for (auto &reg : {TCUR0, TCUR1}) {
-    uint32_t tcur = 0x2000;
-    EXPECT_CALL(mockAdapter, read(baseAddr + reg)).WillOnce(Return(tcur));
-    EXPECT_CALL(mockAdapter, write(baseAddr + reg, tcur));
-  }
-  oclaIP->configure(cfg);
+  cfg.boolcomp = ocla_trigger_bool_comp::XOR;
+  cfg.mode = ocla_trigger_mode::PRE;
+  cfg.fns = true;
+  cfg.ns = 1234;
+  EXPECT_CALL(mockAdapter, write(TMTR, 0x4d101d));
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.configure(cfg);
 }
 
-TEST_F(OclaIPTest, configureTriggerTriggerNodeTest) {
-  uint32_t channel = 1;  // channel 1 to 4
-  ocla_trigger_config trig_cfg;
-  trig_cfg.type = ocla_trigger_type::TRIGGER_NONE;
-  trig_cfg.event = ocla_trigger_event::EQUAL;
-  trig_cfg.value = 333;
-  trig_cfg.probe_num = 1;
+TEST_F(OclaIPTest, configureChannelTest_Edge) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(3 << 24));
+  ON_CALL(mockAdapter, read(TSSR + 0x90)).WillByDefault(Return(0x3ff));
+  ON_CALL(mockAdapter, read(TCUR + 0x90)).WillByDefault(Return(0xffffffff));
+  ON_CALL(mockAdapter, read(TDCR + 0x90)).WillByDefault(Return(0xffffffff));
 
-  EXPECT_CALL(mockAdapter, read(baseAddr + TCUR0)).WillOnce(Return(1));
-  EXPECT_CALL(mockAdapter, write(baseAddr + TCUR0, _));
-  oclaIP->configure_channel(channel, trig_cfg);
+  ocla_trigger_config cfg;
+
+  cfg.type = ocla_trigger_type::EDGE;
+  cfg.event = ocla_trigger_event::RISING;
+  cfg.probe_num = 7;
+  cfg.value_bitwidth = 0;
+  cfg.value = 0;
+
+  EXPECT_CALL(mockAdapter, write(TSSR + 0x90, 7)).Times(1);
+  EXPECT_CALL(mockAdapter, write(TCUR + 0x90, 0xfffffff5)).Times(1);
+  EXPECT_CALL(mockAdapter, write(TDCR + 0x90, 0xffffffff)).Times(1);
+
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.configure_channel(3, cfg);
 }
 
-TEST_F(OclaIPTest, configureTriggerValueCompareTest) {
-  uint32_t channel = 3;  // channel 1 to 4
-  ocla_trigger_config trig_cfg;
-  trig_cfg.type = ocla_trigger_type::VALUE_COMPARE;
-  trig_cfg.event = ocla_trigger_event::EQUAL;
-  trig_cfg.value = 444;
-  trig_cfg.probe_num = 1;
+TEST_F(OclaIPTest, configureChannelTest_Level) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(3 << 24));
+  ON_CALL(mockAdapter, read(TSSR + 0x30)).WillByDefault(Return(0x3ff));
+  ON_CALL(mockAdapter, read(TCUR + 0x30)).WillByDefault(Return(0xffffffff));
+  ON_CALL(mockAdapter, read(TDCR + 0x30)).WillByDefault(Return(0xffffffff));
 
-  EXPECT_CALL(mockAdapter, read(baseAddr + TCUR1)).WillOnce(Return(1));
-  EXPECT_CALL(mockAdapter, write(baseAddr + TDCR, trig_cfg.value));
-  EXPECT_CALL(mockAdapter, write(baseAddr + TCUR1, _));
-  oclaIP->configure_channel(channel, trig_cfg);
+  ocla_trigger_config cfg;
+
+  cfg.type = ocla_trigger_type::LEVEL;
+  cfg.event = ocla_trigger_event::LOW;
+  cfg.probe_num = 999;
+  cfg.value_bitwidth = 0;
+  cfg.value = 0;
+
+  EXPECT_CALL(mockAdapter, write(TSSR + 0x30, 999)).Times(1);
+  EXPECT_CALL(mockAdapter, write(TCUR + 0x30, 0xffffffce)).Times(1);
+  EXPECT_CALL(mockAdapter, write(TDCR + 0x30, 0xffffffff)).Times(1);
+
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.configure_channel(1, cfg);
+}
+
+TEST_F(OclaIPTest, configureChannelTest_ValueCompare) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(3 << 24));
+  ON_CALL(mockAdapter, read(TSSR + 0x60)).WillByDefault(Return(0x3ff));
+  ON_CALL(mockAdapter, read(TCUR + 0x60)).WillByDefault(Return(0xffffffff));
+  ON_CALL(mockAdapter, read(TDCR + 0x60)).WillByDefault(Return(0xffffffff));
+
+  ocla_trigger_config cfg;
+
+  cfg.type = ocla_trigger_type::VALUE_COMPARE;
+  cfg.event = ocla_trigger_event::EQUAL;
+  cfg.probe_num = 21;
+  cfg.value_bitwidth = 12;
+  cfg.value = 1234;
+
+  EXPECT_CALL(mockAdapter, write(TSSR + 0x60, (11u << 24) + 21)).Times(1);
+  EXPECT_CALL(mockAdapter, write(TCUR + 0x60, 0xffffff7f)).Times(1);
+  EXPECT_CALL(mockAdapter, write(TDCR + 0x60, 1234)).Times(1);
+
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.configure_channel(2, cfg);
 }
 
 TEST_F(OclaIPTest, startTest) {
-  EXPECT_CALL(mockAdapter, read(baseAddr + TCUR0)).WillOnce(Return(1));
-  EXPECT_CALL(mockAdapter, write(baseAddr + TCUR0, 1));
-  uint32_t tmtr = 0x20;
-  EXPECT_CALL(mockAdapter, read(baseAddr + TMTR)).WillOnce(Return(tmtr));
-  tmtr |= (1 << 2);
-  EXPECT_CALL(mockAdapter, write(baseAddr + TMTR, tmtr));
-  oclaIP->start();
+  EXPECT_CALL(mockAdapter, write(OCCR, 0x1));
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.start();
 }
 
-TEST_F(OclaIPTest, getDataTest) {
-  const uint32_t ocsr = 0xdeadbeef;
-  const uint32_t tmtr = 0xAABBCCDD;
-  EXPECT_CALL(mockAdapter, read(baseAddr + OCSR)).WillOnce(Return(ocsr));
-  EXPECT_CALL(mockAdapter, read(baseAddr + TMTR)).WillOnce(Return(tmtr));
+TEST_F(OclaIPTest, resetTest) {
+  EXPECT_CALL(mockAdapter, write(OCCR, 0x2));
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.reset();
+}
 
-  ocla_data data;
-  if ((tmtr >> 3) & 0x1) {
-    data.depth = (tmtr >> 4) & 0x7ff;
-  } else {
-    data.depth = (ocsr >> 11) & 0x3ff;
-  }
+TEST_F(OclaIPTest, getDataTest_FixSampleSize) {
+  ON_CALL(mockAdapter, read(TMTR))
+      .WillByDefault(Return((127u << 12) + (1u << 4)));
+  ON_CALL(mockAdapter, read(UIDP0)).WillByDefault(Return(1000));
+  ON_CALL(mockAdapter, read(UIDP1)).WillByDefault(Return(33));
+  EXPECT_CALL(mockAdapter, read(TBDR, 256, 0))
+      .Times(1)
+      .WillOnce(Return(std::vector<uint32_t>(256, 0)));
 
-  data.width = (ocsr >> 1) & 0x3ff;
-  data.num_reads = ((data.width - 1) / 32) + 1;
-  const uint32_t count = data.depth * data.num_reads;
-  std::vector<uint32_t> expectedValues = data.values;
-  EXPECT_CALL(mockAdapter, read(baseAddr + TBDR, count, 0))
-      .WillOnce(Return(expectedValues));
+  OclaIP oclaIP(&mockAdapter, 0);
+  auto result = oclaIP.get_data();
+  EXPECT_EQ(128, result.depth);
+  EXPECT_EQ(33, result.width);
+  EXPECT_EQ(2, result.num_reads);
+  EXPECT_EQ(256, result.values.size());
+}
 
-  auto result = oclaIP->get_data();
-  EXPECT_EQ(data.depth, result.depth);
-  EXPECT_EQ(data.width, result.width);
-  EXPECT_EQ(data.num_reads, result.num_reads);
-  EXPECT_EQ(data.values.size(), result.values.size());
+TEST_F(OclaIPTest, getDataTest_End2End) {
+  ON_CALL(mockAdapter, read(UIDP0)).WillByDefault(Return(1000));
+  ON_CALL(mockAdapter, read(UIDP1)).WillByDefault(Return(65));
+
+  ocla_config cfg;
+
+  cfg.boolcomp = ocla_trigger_bool_comp::OR;
+  cfg.mode = ocla_trigger_mode::POST;
+  cfg.fns = true;
+  cfg.ns = 988;
+
+  EXPECT_CALL(mockAdapter, read(TBDR, 988 * 3, 0))
+      .Times(1)
+      .WillOnce(Return(std::vector<uint32_t>(988 * 3, 0)));
+
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.configure(cfg);
+  auto result = oclaIP.get_data();
+  EXPECT_EQ(988, result.depth);
+  EXPECT_EQ(65, result.width);
+  EXPECT_EQ(3, result.num_reads);
+  EXPECT_EQ(988 * 3, result.values.size());
+}
+
+TEST_F(OclaIPTest, getDataTest_ConfigReadback) {
+  ON_CALL(mockAdapter, read(UIDP0)).WillByDefault(Return(1000));
+  ON_CALL(mockAdapter, read(UIDP1)).WillByDefault(Return(65));
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return((5u << 24)));
+
+  ocla_trigger_config cfg;
+
+  cfg.type = ocla_trigger_type::VALUE_COMPARE;
+  cfg.event = ocla_trigger_event::EQUAL;
+  cfg.probe_num = 17;
+  cfg.value = 123;
+  cfg.value_bitwidth = 12;
+
+  OclaIP oclaIP(&mockAdapter, 0);
+  oclaIP.configure_channel(5, cfg);
+  auto result = oclaIP.get_channel_config(5);
+  EXPECT_EQ(cfg.type, result.type);
+  EXPECT_EQ(cfg.event, result.event);
+  EXPECT_EQ(cfg.probe_num, result.probe_num);
+  EXPECT_EQ(cfg.value, result.value);
+  EXPECT_EQ(cfg.value_bitwidth, result.value_bitwidth);
+}
+
+TEST_F(OclaIPTest, getConfigTest_default) {
+  OclaIP oclaIP(&mockAdapter, 0);
+  ocla_config configData = oclaIP.get_config();
+  EXPECT_EQ(ocla_trigger_bool_comp::DEFAULT, configData.boolcomp);
+  EXPECT_EQ(ocla_trigger_mode::CONTINUOUS, configData.mode);
+  EXPECT_EQ(false, configData.fns);
+  EXPECT_EQ(1, configData.ns);
 }
 
 TEST_F(OclaIPTest, getConfigTest) {
-  uint32_t tmtr = 0x12345678;
-  uint32_t tcur0 = 0x8002;
-  uint32_t tcur1 = 0x7001;
-  ocla_config cfg;
-  cfg.mode = (ocla_mode)(tmtr & 0x3);
-  cfg.fns = (ocla_fns)((tmtr >> 3) & 0x1);
-  cfg.ns = ((tmtr >> 4) & 0x7ff);
-  cfg.st = ((tmtr >> 2) & 1);
-
-  EXPECT_CALL(mockAdapter, read(baseAddr + TMTR)).WillOnce(Return(tmtr));
-  EXPECT_CALL(mockAdapter, read(baseAddr + TCUR0)).WillOnce(Return(tcur0));
-  EXPECT_CALL(mockAdapter, read(baseAddr + TCUR1)).WillOnce(Return(tcur1));
-
-  tcur0 = ((tcur0 >> 15) & 3);
-  tcur1 = ((tcur1 >> 15) & 3);
-  cfg.condition = tcur0 == tcur1 ? (ocla_trigger_condition)tcur0 : DEFAULT;
-
-  ocla_config configData = oclaIP->get_config();
-  EXPECT_EQ(cfg.condition, configData.condition);
-  EXPECT_EQ(cfg.mode, configData.mode);
-  EXPECT_EQ(cfg.fns, configData.fns);
-  EXPECT_EQ(cfg.ns, configData.ns);
-  EXPECT_EQ(cfg.st, configData.st);
+  ON_CALL(mockAdapter, read(TMTR)).WillByDefault(Return(0x59ac5599));
+  OclaIP oclaIP(&mockAdapter, 0);
+  ocla_config configData = oclaIP.get_config();
+  EXPECT_EQ(ocla_trigger_bool_comp::OR, configData.boolcomp);
+  EXPECT_EQ(ocla_trigger_mode::PRE, configData.mode);
+  EXPECT_EQ(true, configData.fns);
+  EXPECT_EQ(367302, configData.ns);
 }
 
-TEST_F(OclaIPTest, getChannelConfigTest) {
-  uint32_t channel = 1;
-  uint32_t tcur = 0x10a1aabb;
-  EXPECT_CALL(mockAdapter, read(baseAddr + (channel < 2 ? TCUR0 : TCUR1)))
-      .WillOnce(::testing::Return(tcur));
+TEST_F(OclaIPTest, getChannelConfigTest_Edge) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(0x3000000));
+  ON_CALL(mockAdapter, read(TSSR + 0x90)).WillByDefault(Return(0x3e7));
+  ON_CALL(mockAdapter, read(TCUR + 0x90))
+      .WillByDefault(Return(0xfffffff0 + 0x9));
+  OclaIP oclaIP(&mockAdapter, 0);
+  ocla_trigger_config configData = oclaIP.get_channel_config(3);
+  EXPECT_EQ(ocla_trigger_type::EDGE, configData.type);
+  EXPECT_EQ(ocla_trigger_event::FALLING, configData.event);
+  EXPECT_EQ(999, configData.probe_num);
+  EXPECT_EQ(0, configData.value);
+  EXPECT_EQ(0, configData.value_bitwidth);
+}
 
-  ocla_trigger_config result = oclaIP->get_channel_config(channel);
+TEST_F(OclaIPTest, getChannelConfigTest_Level) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(0x3000000));
+  ON_CALL(mockAdapter, read(TSSR + 0x90)).WillByDefault(Return(123));
+  ON_CALL(mockAdapter, read(TCUR + 0x90))
+      .WillByDefault(Return(0xffffff00 + 0x1e));
+  OclaIP oclaIP(&mockAdapter, 0);
+  ocla_trigger_config configData = oclaIP.get_channel_config(3);
+  EXPECT_EQ(ocla_trigger_type::LEVEL, configData.type);
+  EXPECT_EQ(ocla_trigger_event::HIGH, configData.event);
+  EXPECT_EQ(123, configData.probe_num);
+  EXPECT_EQ(0, configData.value);
+  EXPECT_EQ(0, configData.value_bitwidth);
+}
 
-  ocla_trigger_config expected;
-  expected.probe_num = 16;
-  expected.type = LEVEL;
-  expected.event = ocla_trigger_event::LOW;
+TEST_F(OclaIPTest, getChannelConfigTest_ValueCompare) {
+  ON_CALL(mockAdapter, read(OCSR)).WillByDefault(Return(0x3000000));
+  ON_CALL(mockAdapter, read(TSSR + 0x90))
+      .WillByDefault(Return((7 << 24) + 123));
+  ON_CALL(mockAdapter, read(TCUR + 0x90))
+      .WillByDefault(Return(0xffffff00 + 0x7f));
+  ON_CALL(mockAdapter, read(TDCR + 0x90)).WillByDefault(Return(99));
+  OclaIP oclaIP(&mockAdapter, 0);
+  ocla_trigger_config configData = oclaIP.get_channel_config(3);
+  EXPECT_EQ(ocla_trigger_type::VALUE_COMPARE, configData.type);
+  EXPECT_EQ(ocla_trigger_event::EQUAL, configData.event);
+  EXPECT_EQ(123, configData.probe_num);
+  EXPECT_EQ(99, configData.value);
+  EXPECT_EQ(8, configData.value_bitwidth);
+}
 
-  EXPECT_EQ(result.probe_num, expected.probe_num);
-  EXPECT_EQ(result.type, expected.type);
-  EXPECT_EQ(result.event, expected.event);
+TEST_F(OclaIPTest, getChannelConfigTest_default) {
+  OclaIP oclaIP(&mockAdapter, 0);
+  ocla_trigger_config configData = oclaIP.get_channel_config(0);
+  EXPECT_EQ(ocla_trigger_type::TRIGGER_NONE, configData.type);
+  EXPECT_EQ(ocla_trigger_event::NONE, configData.event);
+  EXPECT_EQ(0, configData.probe_num);
+  EXPECT_EQ(0, configData.value);
+  EXPECT_EQ(0, configData.value_bitwidth);
 }


### PR DESCRIPTION
This PR updated the new OCLA IP's register address map which has changed in OCLA Phase 2 Project by the IP team. The changes included in the PR are as below:

1. Updated the register addresses used to configure the OCLA instances and trigger channel settings
2. Updated all unit tests
3. Improved the burst reading of trace buffer data register by using TCL proc

Regression tests and validation have been performed on the OCLA test platform. See screenshot below:-

![image](https://github.com/os-fpga/FOEDAG_rs/assets/12110149/0c51d4da-b35a-41d3-b595-9dced3dccde3)
 