### PR TITLE
install bzip2-devel libffi-devel for Python on CentOS

### DIFF
--- a/.github/workflows/install_centos_dependencies_build.sh
+++ b/.github/workflows/install_centos_dependencies_build.sh
@@ -29,7 +29,7 @@ yum install -y pkgconfig
 yum install -y perl-IPC-Cmd
 yum install -y alsa-lib
 yum install -y boost boost-devel boost-static openssl-static
-yum install -y python3-devel
+yum install -y python3-devel bzip2-devel libffi-devel
 
 ln -s $PWD/cmake-3.24.4-linux-x86_64/bin/ctest /usr/bin/ctest
 echo 'QMAKE_CC=/opt/rh/devtoolset-11/root/usr/bin/gcc' >> $GITHUB_ENV


### PR DESCRIPTION
To build FOEDAG_rs with CPython support, install bzip2-devel libffi-devel on CentOS 7 