### PR TITLE
Support configuration of BRAM parity

### DIFF
--- a/src/ConfigurationRS/BitAssembler/BitAssembler_mgr.h
+++ b/src/ConfigurationRS/BitAssembler/BitAssembler_mgr.h
@@ -37,18 +37,17 @@ class BitAssembler_MGR {
  private:
   template <typename T>
   uint32_t get_bitline_into_bytes(T& start, T& end, std::vector<uint8_t>& bytes,
+                                  std::vector<uint8_t>* mask_bytes,
                                   uint32_t size = 0);
   uint32_t get_bitline_into_bytes(const std::string& line,
                                   std::vector<uint8_t>& bytes,
                                   const uint32_t expected_bit = 0,
                                   const bool lsb = true);
-  uint32_t get_wl_bitline_into_bytes(const std::string& line,
-                                     std::vector<uint8_t>& bytes,
-                                     const uint32_t expected_bl_bit,
-                                     const uint32_t expected_wl_bit,
-                                     const uint32_t expected_wl,
-                                     const bool lsb = true,
-                                     uint32_t* one_hot_wl = nullptr);
+  uint32_t get_wl_bitline_into_bytes(
+      const std::string& line, std::vector<uint8_t>& bytes,
+      std::vector<uint8_t>& mask_bytes, const uint32_t expected_bl_bit,
+      const uint32_t expected_wl_bit, const uint32_t expected_wl,
+      const bool lsb = true, uint32_t* one_hot_wl = nullptr);
   const std::string m_project_path;
   const std::string m_device;
 };

--- a/src/ConfigurationRS/BitGenerator/BitGen_gemini.h
+++ b/src/ConfigurationRS/BitGenerator/BitGen_gemini.h
@@ -20,12 +20,24 @@ class BitGen_GEMINI {
       const std::vector<uint8_t>& src_data, uint64_t line_bits,
       uint64_t total_line, uint64_t src_unit_bits, uint64_t dest_unit_bits,
       bool pad_reversed, bool unit_reversed);
-  void get_pcb_payload_and_parity(std::vector<uint8_t>& data,
-                                  std::vector<uint8_t>& payload,
-                                  std::vector<uint8_t>& parity);
+  void get_pcb_user_data_and_parity(std::vector<uint8_t>& data,
+                                    std::vector<uint8_t>& user_data,
+                                    std::vector<uint8_t>& parity);
   void get_pcb_xy_offset_stride(const std::vector<CFGObject_BITOBJ_PCB*>& pcbs,
                                 uint32_t& row_offset, uint32_t& row_stride,
                                 uint32_t& col_offset, uint32_t& col_stride);
+  bool get_data_bit(std::vector<uint8_t>& data, size_t index);
+  void append_assign_data_bit(std::vector<uint8_t>& data, bool value,
+                              size_t index);
+  void adjust_data_bit_size(std::vector<uint8_t>& data, size_t original_size,
+                            size_t new_size, size_t count,
+                            bool value_to_adjust = false,
+                            bool include_remaining = false);
+  void append_alternate_data(std::vector<uint8_t>& data,
+                             std::vector<uint8_t>& data0,
+                             std::vector<uint8_t>& data1, size_t bit_size,
+                             size_t count, size_t dest_index,
+                             bool check_byte_alignment);
 
  private:
   const CFGObject_BITOBJ* m_bitobj;

--- a/src/ConfigurationRS/BitGenerator/BitGen_json.cpp
+++ b/src/ConfigurationRS/BitGenerator/BitGen_json.cpp
@@ -279,7 +279,21 @@ const std::map<const std::string, const BitGen_JSON_ACTION_FIELD>
           {"pl_extra_w32", std::make_pair(128, 1)},
           {"pl_extra_w33", std::make_pair(129, 1)},
           {"pl_extra_w34", std::make_pair(130, 1)},
-          {"pl_extra_w35", std::make_pair(131, 1)}}}};
+          {"pl_extra_w35", std::make_pair(131, 1)}}},
+        {"pcb_config_with_parity",
+         {{"ram_block_count", std::make_pair(0, 16)},
+          {"pl_ctl_skew", std::make_pair(16, 2)},
+          {"pl_ctl_parity", std::make_pair(18, 1)},
+          {"pl_ctl_even", std::make_pair(19, 1)},
+          {"pl_ctl_split", std::make_pair(20, 2)},
+          {"pl_select_offset", std::make_pair(32, 12)},
+          {"pl_select_row", std::make_pair(44, 10)},
+          {"pl_select_col", std::make_pair(54, 10)},
+          {"pl_row_offset", std::make_pair(64, 10)},
+          {"pl_row_stride", std::make_pair(80, 10)},
+          {"pl_col_offset", std::make_pair(96, 10)},
+          {"pl_col_stride", std::make_pair(112, 10)},
+          {"reversed", std::make_pair(128, 32)}}}};
 
 static const BitGen_JSON_ACTION_FIELD* BitGen_JSON_get_action_database(
     const std::string& action) {
@@ -516,6 +530,13 @@ BitGen_BITSTREAM_ACTION* BitGen_JSON::gen_pcb_config_action(
     const nlohmann::json& json) {
   return gen_standard_action(json, "Bitstream PCB Config Action", "pcb_config",
                              0x004, true, false, false);
+}
+
+BitGen_BITSTREAM_ACTION* BitGen_JSON::gen_pcb_config_with_parity_action(
+    const nlohmann::json& json) {
+  return gen_standard_action(json, "Bitstream PCB Config With Parity Action",
+                             "pcb_config_with_parity", 0x005, true, false,
+                             false);
 }
 
 BitGen_BITSTREAM_ACTION* BitGen_JSON::gen_auth_key_otp_programming_action(

--- a/src/ConfigurationRS/BitGenerator/BitGen_json.h
+++ b/src/ConfigurationRS/BitGenerator/BitGen_json.h
@@ -20,6 +20,8 @@ class BitGen_JSON {
       const nlohmann::json& json);
   static BitGen_BITSTREAM_ACTION* gen_pcb_config_action(
       const nlohmann::json& json);
+  static BitGen_BITSTREAM_ACTION* gen_pcb_config_with_parity_action(
+      const nlohmann::json& json);
   static BitGen_BITSTREAM_ACTION* gen_auth_key_otp_programming_action(
       const nlohmann::json& json);
   static BitGen_BITSTREAM_ACTION* gen_aes_key_otp_programming_action(

--- a/src/ConfigurationRS/CFGObject/CFGObject.json
+++ b/src/ConfigurationRS/CFGObject/CFGObject.json
@@ -71,6 +71,11 @@
           "name" : "data",
           "type" : "u8s",
           "cmp"  : true
+        },
+        {
+          "name" : "mask",
+          "type" : "u8s",
+          "cmp"  : true
         }
       ],
       "exist" : false

--- a/src/ConfigurationRS/CFGObject/CFGObject.py
+++ b/src/ConfigurationRS/CFGObject/CFGObject.py
@@ -68,7 +68,7 @@ class element :
     assert isinstance(self.compress, bool), "Element %s compress paramter must be boolean, but found %s" % type(self.compress)
     assert self.type in SUPPORTED_TYPES, "Element %s type %s is not supported (%s)" % (self.name, self.type, SUPPORTED_TYPES)
     if self.type != None :
-      assert not self.list, "None-clasee element %s (%s) does not support list parameter" % (self.name, self.type)
+      assert not self.list, "None-class element %s (%s) does not support list parameter" % (self.name, self.type)
 
 def check_element(values, name, siblings, level=0) :
 


### PR DESCRIPTION
1. Support BRAM parity bits configuration (this is by default supported flow)
2. Support retrieval of mask from fabric_bitstream.bit (Prepare future usage to if we support readback comparison)

