### PR TITLE
OCLA Debugger Phase 2 - enable signal bitrange selection

### DIFF
--- a/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
+++ b/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
@@ -764,7 +764,7 @@
             "name": "compare_width",
             "short": "w",
             "type": "int",
-            "default": 1,
+            "default": 0,
             "optional": true,
             "help": "Compare value width (no. of bits)"
           }
@@ -859,7 +859,7 @@
             "name": "compare_width",
             "short": "w",
             "type": "int",
-            "default": 1,
+            "default": 0,
             "optional": true,
             "help": "Compare value width (no. of bits)"
           }

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -169,8 +169,13 @@ void Ocla::add_trigger(uint32_t domain_id, uint32_t probe_id,
   // unless overrided by compare width param
   if (trig.cfg.type == ocla_trigger_type::VALUE_COMPARE) {
     if (compare_width == 0) {
-      trig.cfg.compare_width =
-          trig.bitrange_enable ? trig.width : signal->get_bitwidth();
+      if (trig.bitrange_enable) {
+        trig.cfg.compare_width =
+            std::min(trig.width, ocla_ip.get_max_compare_value_size());
+      } else {
+        trig.cfg.compare_width = std::min(signal->get_bitwidth(),
+                                          ocla_ip.get_max_compare_value_size());
+      }
     }
   }
 
@@ -288,8 +293,13 @@ void Ocla::edit_trigger(uint32_t domain_id, uint32_t trigger_index,
   // unless overrided by compare width param
   if (trig->cfg.type == ocla_trigger_type::VALUE_COMPARE) {
     if (compare_width == 0) {
-      trig->cfg.compare_width =
-          trig->bitrange_enable ? trig->width : signal->get_bitwidth();
+      if (trig->bitrange_enable) {
+        trig->cfg.compare_width =
+            std::min(trig->width, ocla_ip.get_max_compare_value_size());
+      } else {
+        trig->cfg.compare_width = std::min(
+            signal->get_bitwidth(), ocla_ip.get_max_compare_value_size());
+      }
     }
   }
 }

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -63,6 +63,7 @@ class Ocla {
   void show_signal_table(std::vector<OclaSignal> signals_list);
   void program(OclaDomain *domain);
   bool verify(OclaDebugSession *session);
+  std::string format_signal_name(oc_trigger_t &trig);
 };
 
 void Ocla_entry(CFGCommon_ARG *cmdarg);

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -39,10 +39,11 @@ class Ocla {
   void add_trigger(uint32_t domain_id, uint32_t probe_id,
                    std::string signal_name, std::string type, std::string event,
                    uint32_t value, uint32_t compare_width);
-  void edit_trigger(uint32_t domain_id, uint32_t trigger_id, uint32_t probe_id,
-                    std::string signal_name, std::string type,
-                    std::string event, uint32_t value, uint32_t compare_width);
-  void remove_trigger(uint32_t domain_id, uint32_t trigger_id);
+  void edit_trigger(uint32_t domain_id, uint32_t trigger_index,
+                    uint32_t probe_id, std::string signal_name,
+                    std::string type, std::string event, uint32_t value,
+                    uint32_t compare_width);
+  void remove_trigger(uint32_t domain_id, uint32_t trigger_index);
   bool get_waveform(uint32_t domain_id, oc_waveform_t &output);
   bool get_status(uint32_t domain_id, uint32_t &status);
   bool start(uint32_t domain_id);

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.h
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.h
@@ -16,7 +16,8 @@ class OclaDebugSession {
   std::vector<OclaDomain> m_clock_domains;
   std::string m_filepath;
   bool m_loaded;
-  OclaSignal parse_signal(std::string signal_str);
+  bool parse_signal(std::string signal_str, OclaSignal& signal,
+                    std::vector<std::string>& error_messages);
   bool parse(std::string ocla_str, std::vector<std::string>& error_messages);
 
  public:

--- a/src/ConfigurationRS/Ocla/OclaDomain.cpp
+++ b/src/ConfigurationRS/Ocla/OclaDomain.cpp
@@ -34,3 +34,39 @@ void OclaDomain::set_config(ocla_config& config) { m_config = config; }
 void OclaDomain::add_trigger(oc_trigger_t& trig) { m_triggers.push_back(trig); }
 
 std::vector<oc_trigger_t>& OclaDomain::get_triggers() { return m_triggers; }
+
+bool OclaDomain::get_instance(uint32_t instance_index, OclaInstance*& output) {
+  for (auto& instance : m_instances) {
+    if (instance.get_index() == instance_index) {
+      output = &instance;
+      return true;
+    }
+  }
+  return false;
+}
+
+uint32_t OclaDomain::get_number_of_triggers(uint32_t instance_index) {
+  uint32_t count = 0;
+  for (auto& trig : m_triggers) {
+    if (trig.instance_index == instance_index) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+bool OclaDomain::get_trigger(uint32_t trigger_index, oc_trigger_t*& output) {
+  if (trigger_index > 0 && trigger_index <= m_triggers.size()) {
+    output = &m_triggers[trigger_index - 1];
+    return true;
+  }
+  return false;
+}
+
+bool OclaDomain::remove_trigger(uint32_t trigger_index) {
+  if (trigger_index > 0 && trigger_index <= m_triggers.size()) {
+    m_triggers.erase(m_triggers.begin() + (trigger_index - 1));
+    return true;
+  }
+  return false;
+}

--- a/src/ConfigurationRS/Ocla/OclaDomain.h
+++ b/src/ConfigurationRS/Ocla/OclaDomain.h
@@ -17,6 +17,10 @@ struct oc_trigger_t {
   uint32_t probe_id;
   uint32_t signal_id;
   std::string signal_name;
+  // fields to support sub bit range selection in the selected signal
+  bool bitrange_enable;
+  uint32_t pos;
+  uint32_t width;
 };
 
 class OclaDomain {

--- a/src/ConfigurationRS/Ocla/OclaDomain.h
+++ b/src/ConfigurationRS/Ocla/OclaDomain.h
@@ -42,10 +42,14 @@ class OclaDomain {
   void set_index(uint32_t idx);
   std::vector<OclaProbe>& get_probes();
   std::vector<OclaInstance>& get_instances();
+  bool get_instance(uint32_t instance_index, OclaInstance*& output);
   ocla_config get_config() const;
   void set_config(ocla_config& config);
   void add_trigger(oc_trigger_t& trig);
   std::vector<oc_trigger_t>& get_triggers();
+  bool get_trigger(uint32_t trigger_index, oc_trigger_t*& output);
+  uint32_t get_number_of_triggers(uint32_t instance_index);
+  bool remove_trigger(uint32_t trigger_index);
 };
 
 #endif  //__OCLADOMAIN_H__

--- a/src/ConfigurationRS/Ocla/OclaHelpers.h
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.h
@@ -6,6 +6,12 @@
 
 #include "OclaIP.h"
 
+#define OCLA_SIGNAL_PATTERN_1 (1)  // pattern 1: count[13:2]
+#define OCLA_SIGNAL_PATTERN_2 (2)  // pattern 2: 4'0000
+#define OCLA_SIGNAL_PATTERN_3 (3)  // pattern 3: s_axil_awprot[0]
+#define OCLA_SIGNAL_PATTERN_4 (4)  // pattern 4: 3
+#define OCLA_SIGNAL_PATTERN_5 (5)  // pattern 5: s_axil_bready
+
 std::string convert_ocla_trigger_mode_to_string(
     ocla_trigger_mode mode, std::string defval = "(unknown)");
 
@@ -45,5 +51,9 @@ void CFG_write_bit_vec32(uint32_t *data, uint32_t pos, uint32_t value);
 
 void CFG_copy_bits_vec32(uint32_t *src, uint32_t pos, uint32_t *dest,
                          uint32_t dest_pos, uint32_t nbits);
+
+uint32_t CFG_parse_signal(std::string &signal_str, std::string &name,
+                          uint32_t &bit_start, uint32_t &bit_end,
+                          uint32_t &bit_width, uint32_t &value);
 
 #endif  //__OCLAHELPERS_H__

--- a/src/ConfigurationRS/Ocla/OclaIP.h
+++ b/src/ConfigurationRS/Ocla/OclaIP.h
@@ -70,7 +70,7 @@
 #define TSSR_PS_Width (10)
 #define TSSR_PS_Msk (((1u << TSSR_PS_Width) - 1) << TSSR_PS_Pos)
 #define TSSR_CW_Pos (24)
-#define TSSR_CW_Width (5)
+#define TSSR_CW_Width (6)
 #define TSSR_CW_Msk (((1u << TSSR_CW_Width) - 1) << TSSR_CW_Pos)
 
 // TCUR (Trigger Control Unit Register) bitfield definitions


### PR DESCRIPTION
This PR enables the signal bitrange selection when adding / editing an trigger so that one can setup a trigger on any bit or range of bits of a bus type signal.

Changes:-
1. in edit_trigger command, check trigger limit when the probe is changed
2. check compare width limit when add or edit an trigger cfg
3. Minor code refactor