### PR TITLE
Update main.yml to stick to macos 12 to support py3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,7 +421,7 @@ jobs:
           ${{ github.workspace }}/build/tests/
 
   macos-gcc:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
 
@@ -483,7 +483,7 @@ jobs:
          make regression
 
   macos-clang:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
 


### PR DESCRIPTION
The latest GitHub runners are using MacOS 14 now and this MacOS version does not support Python 3.8 while we still want to support Python 3.8 due to CentOS 7 so making sure CI runs on MacOS 12