### PR TITLE
OCLA Debugger Phase 2 - Enable EIO feature and CLI commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,7 +421,7 @@ jobs:
           ${{ github.workspace }}/build/tests/
 
   macos-gcc:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
 
@@ -483,7 +483,7 @@ jobs:
          make regression
 
   macos-clang:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,7 +421,7 @@ jobs:
           ${{ github.workspace }}/build/tests/
 
   macos-gcc:
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
 
@@ -483,7 +483,7 @@ jobs:
          make regression
 
   macos-clang:
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
 

--- a/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
+++ b/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
@@ -923,6 +923,103 @@
       }
     },
     {
+      "set_io": {
+        "option": [
+          {
+            "name": "cable",
+            "short": "b",
+            "type": "str",
+            "optional": true,
+            "default" : "1",
+            "help": "Cable name or index"
+          },
+          {
+            "name": "device",
+            "short": "d",
+            "type": "int",
+            "optional": true,
+            "default" : 1,
+            "help": "Device index"
+          },
+          {
+            "name": "signal",
+            "short": "s",
+            "type": "str",
+            "optional": false,
+            "help": "Signal name or index"
+          },
+          {
+            "name": "value",
+            "short": "v",
+            "type": "int",
+            "optional": false,
+            "help": "IO value/state"
+          }
+        ],
+        "desc": "To configure the state/value of an IO signal.",
+        "help": [
+          "To configure a IO value/state:",
+          "  debugger set_io",
+          "  -s <name/index>",
+          "  -v <value>"
+        ]
+      }
+    },
+    {
+      "get_io": {
+        "option": [
+          {
+            "name": "cable",
+            "short": "b",
+            "type": "str",
+            "optional": true,
+            "default" : "1",
+            "help": "Cable name or index"
+          },
+          {
+            "name": "device",
+            "short": "d",
+            "type": "int",
+            "optional": true,
+            "default" : 1,
+            "help": "Device index"
+          },
+          {
+            "name": "signal",
+            "short": "s",
+            "type": "str",
+            "multi": true,
+            "optional": false,
+            "help": "Signal name or index"
+          },
+          {
+            "name": "loop",
+            "short": "l",
+            "type": "int",
+            "optional": true,
+            "default" : 1,
+            "help": "Read for a specified number of times (default 1)"
+          },
+          {
+            "name": "duration",
+            "short": "t",
+            "type": "int",
+            "optional": true,
+            "default" : 100,
+            "help": "Time interval between reads in millisecond (default 100ms)"
+          }
+        ],
+        "desc": "To read the state/value of an IO signal.",
+        "help": [
+          "To read a IO value/state:",
+          "  debugger get_io",
+          "  -s <name/index>",
+          "  -l {times}",
+          "  -t {milliseconds}"
+        ]
+      }
+    },
+    {
       "help": "Configuration File Generation Internal Tool"
     }
   ]

--- a/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
+++ b/src/ConfigurationRS/CFGCommonRS/CFGArgRS.json
@@ -945,6 +945,7 @@
             "name": "signal",
             "short": "s",
             "type": "str",
+            "multi": true,
             "optional": false,
             "help": "Signal name or index"
           },
@@ -952,6 +953,7 @@
             "name": "value",
             "short": "v",
             "type": "int",
+            "multi": true,
             "optional": false,
             "help": "IO value/state"
           }

--- a/src/ConfigurationRS/Ocla/CMakeLists.txt
+++ b/src/ConfigurationRS/Ocla/CMakeLists.txt
@@ -69,6 +69,8 @@ add_library(
   OclaDomain.cpp
   OclaProbe.cpp
   OclaSignal.cpp
+  EioIP.cpp
+  EioInstance.cpp
   ${LIBFST_SOURCE_DIR}/fstapi.c
   ${LIBFST_SOURCE_DIR}/lz4.c
   ${LIBFST_SOURCE_DIR}/fastlz.c
@@ -112,6 +114,7 @@ add_executable(
   Test/Ocla_test.cpp
   Test/OclaHelpersTests.cpp
   Test/OclaIpTests.cpp
+  Test/EioIpTests.cpp
 )
 target_link_libraries(${test_bin} ${subsystem} gtest gmock gtest_main)
 

--- a/src/ConfigurationRS/Ocla/EioIP.cpp
+++ b/src/ConfigurationRS/Ocla/EioIP.cpp
@@ -18,7 +18,7 @@ EioIP::~EioIP() {}
 
 std::string EioIP::get_type() const {
   char buffer[10];
-  uint32_t type = CFG_reverse_byte_order_u32(m_type<<8);
+  uint32_t type = CFG_reverse_byte_order_u32(m_type << 8);
   snprintf(buffer, sizeof(buffer), "%.*s", 4, (char *)&type);
   return std::string(buffer);
 }

--- a/src/ConfigurationRS/Ocla/EioIP.cpp
+++ b/src/ConfigurationRS/Ocla/EioIP.cpp
@@ -1,0 +1,45 @@
+#include "EioIP.h"
+
+#include "ConfigurationRS/CFGCommonRS/CFGCommonRS.h"
+#include "OclaHelpers.h"
+#include "OclaJtagAdapter.h"
+
+EioIP::EioIP(OclaJtagAdapter *adapter, uint32_t baseaddr)
+    : m_adapter(adapter),
+      m_baseaddr(baseaddr),
+      m_ctrl(0),
+      m_type(0),
+      m_version(0),
+      m_id(0) {
+  read_registers();
+}
+
+EioIP::~EioIP() {}
+
+std::string EioIP::get_type() const {
+  char buffer[10];
+  uint32_t type = CFG_reverse_byte_order_u32(m_type<<8);
+  snprintf(buffer, sizeof(buffer), "%.*s", 4, (char *)&type);
+  return std::string(buffer);
+}
+
+uint32_t EioIP::get_version() const { return m_version; }
+
+uint32_t EioIP::get_id() const { return m_id; }
+
+void EioIP::write(uint32_t value, eio_probe_register_t reg) {
+  CFG_ASSERT(m_adapter != nullptr);
+  m_adapter->write(m_baseaddr + EIO_AXI_DAT_OUT + uint32_t(reg), value);
+}
+
+uint32_t EioIP::read(eio_probe_register_t reg) {
+  return m_adapter->read(m_baseaddr + EIO_AXI_DAT_IN + uint32_t(reg));
+}
+
+void EioIP::read_registers() {
+  CFG_ASSERT(m_adapter != nullptr);
+  m_ctrl = m_adapter->read(m_baseaddr + EIO_CTRL);
+  m_type = m_adapter->read(m_baseaddr + EIO_IP_TYPE);
+  m_version = m_adapter->read(m_baseaddr + EIO_IP_VERSION);
+  m_id = m_adapter->read(m_baseaddr + EIO_IP_ID);
+}

--- a/src/ConfigurationRS/Ocla/EioIP.cpp
+++ b/src/ConfigurationRS/Ocla/EioIP.cpp
@@ -27,13 +27,22 @@ uint32_t EioIP::get_version() const { return m_version; }
 
 uint32_t EioIP::get_id() const { return m_id; }
 
-void EioIP::write(uint32_t value, eio_probe_register_t reg) {
+void EioIP::write(std::vector<uint32_t> values, uint32_t length) {
   CFG_ASSERT(m_adapter != nullptr);
-  m_adapter->write(m_baseaddr + EIO_AXI_DAT_OUT + uint32_t(reg), value);
+  CFG_ASSERT(length > 0 && length <= 2);
+  for (uint32_t i = 0; i < length; i++) {
+    m_adapter->write(m_baseaddr + EIO_AXI_DAT_OUT + (i << 2), values[i]);
+  }
 }
 
-uint32_t EioIP::read(eio_probe_register_t reg) {
-  return m_adapter->read(m_baseaddr + EIO_AXI_DAT_IN + uint32_t(reg));
+std::vector<uint32_t> EioIP::read(uint32_t length) {
+  CFG_ASSERT(m_adapter != nullptr);
+  std::vector<uint32_t> values{};
+  auto result = m_adapter->read(m_baseaddr + EIO_AXI_DAT_IN, length, 4);
+  for (auto &r : result) {
+    values.push_back(r.data);
+  }
+  return values;
 }
 
 void EioIP::read_registers() {

--- a/src/ConfigurationRS/Ocla/EioIP.h
+++ b/src/ConfigurationRS/Ocla/EioIP.h
@@ -1,0 +1,41 @@
+#ifndef __EIOIP_H__
+#define __EIOIP_H__
+
+#include <cstdint>
+#include <string>
+
+#define EIO_CTRL (0x00)         // [RW] Control register (Reserved)
+#define EIO_IP_TYPE (0x04)      // [RO] IP Type Register ("EIO")
+#define EIO_IP_VERSION (0x08)   // [RO] Define version of IP
+#define EIO_IP_ID (0x0C)        // [RO] Unique identifier for IP
+#define EIO_AXI_DAT_IN (0x10)   // [RO] Data at the input probes of EIO (received from the DUT)
+#define EIO_AXI_DAT_OUT (0x10)  // [WO] Data at the output probes of EIO (sent to the DUT)
+
+enum eio_probe_register_t {
+    LOWER = 0,
+    UPPER = 4
+};
+
+class OclaJtagAdapter;
+
+class EioIP {
+ public:
+  EioIP(OclaJtagAdapter *adapter, uint32_t baseaddr);
+  ~EioIP();
+  std::string get_type() const;
+  uint32_t get_version() const;
+  uint32_t get_id() const;
+  void write(uint32_t value, eio_probe_register_t reg);
+  uint32_t read(eio_probe_register_t reg);
+
+ private:
+  void read_registers();
+  OclaJtagAdapter *m_adapter;
+  uint32_t m_baseaddr;
+  uint32_t m_ctrl;
+  uint32_t m_type;
+  uint32_t m_version;
+  uint32_t m_id;
+};
+
+#endif  //__EIOIP_H__

--- a/src/ConfigurationRS/Ocla/EioIP.h
+++ b/src/ConfigurationRS/Ocla/EioIP.h
@@ -4,17 +4,16 @@
 #include <cstdint>
 #include <string>
 
-#define EIO_CTRL (0x00)         // [RW] Control register (Reserved)
-#define EIO_IP_TYPE (0x04)      // [RO] IP Type Register ("EIO")
-#define EIO_IP_VERSION (0x08)   // [RO] Define version of IP
-#define EIO_IP_ID (0x0C)        // [RO] Unique identifier for IP
-#define EIO_AXI_DAT_IN (0x10)   // [RO] Data at the input probes of EIO (received from the DUT)
-#define EIO_AXI_DAT_OUT (0x10)  // [WO] Data at the output probes of EIO (sent to the DUT)
+#define EIO_CTRL (0x00)        // [RW] Control register (Reserved)
+#define EIO_IP_TYPE (0x04)     // [RO] IP Type Register ("EIO")
+#define EIO_IP_VERSION (0x08)  // [RO] Define version of IP
+#define EIO_IP_ID (0x0C)       // [RO] Unique identifier for IP
+#define EIO_AXI_DAT_IN \
+  (0x10)  // [RO] Data at the input probes of EIO (received from the DUT)
+#define EIO_AXI_DAT_OUT \
+  (0x10)  // [WO] Data at the output probes of EIO (sent to the DUT)
 
-enum eio_probe_register_t {
-    LOWER = 0,
-    UPPER = 4
-};
+enum eio_probe_register_t { LOWER = 0, UPPER = 4 };
 
 class OclaJtagAdapter;
 

--- a/src/ConfigurationRS/Ocla/EioIP.h
+++ b/src/ConfigurationRS/Ocla/EioIP.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #define EIO_CTRL (0x00)        // [RW] Control register (Reserved)
 #define EIO_IP_TYPE (0x04)     // [RO] IP Type Register ("EIO")
@@ -13,8 +14,6 @@
 #define EIO_AXI_DAT_OUT \
   (0x10)  // [WO] Data at the output probes of EIO (sent to the DUT)
 
-enum eio_probe_register_t { LOWER = 0, UPPER = 4 };
-
 class OclaJtagAdapter;
 
 class EioIP {
@@ -24,8 +23,8 @@ class EioIP {
   std::string get_type() const;
   uint32_t get_version() const;
   uint32_t get_id() const;
-  void write(uint32_t value, eio_probe_register_t reg);
-  uint32_t read(eio_probe_register_t reg);
+  void write(std::vector<uint32_t> values, uint32_t length);
+  std::vector<uint32_t> read(uint32_t length);
 
  private:
   void read_registers();

--- a/src/ConfigurationRS/Ocla/EioInstance.cpp
+++ b/src/ConfigurationRS/Ocla/EioInstance.cpp
@@ -1,0 +1,30 @@
+#include "EioInstance.h"
+
+#include "ConfigurationRS/CFGCommonRS/CFGCommonRS.h"
+#include "OclaHelpers.h"
+
+EioInstance::EioInstance(uint32_t baseaddr) : m_baseaddr(baseaddr) {}
+
+EioInstance::~EioInstance() {}
+
+std::vector<eio_probe_t> EioInstance::get_input_probes()  {
+    return get_probes(eio_probe_type_t::INPUT);
+}
+
+std::vector<eio_probe_t> EioInstance::get_output_probes()  {
+    return get_probes(eio_probe_type_t::OUTPUT);
+}
+
+void EioInstance::add_probe(eio_probe_t &probe) {
+    m_probes.push_back(probe);
+}
+
+std::vector<eio_probe_t> EioInstance::get_probes(eio_probe_type_t type) {
+    std::vector<eio_probe_t> probes{};
+    for (auto &p : m_probes) {
+        if (p.type == type) {
+            probes.push_back(p);
+        }
+    }
+    return probes;
+}

--- a/src/ConfigurationRS/Ocla/EioInstance.cpp
+++ b/src/ConfigurationRS/Ocla/EioInstance.cpp
@@ -12,14 +12,6 @@ uint32_t EioInstance::get_baseaddr() const { return m_baseaddr; }
 
 uint32_t EioInstance::get_index() const { return m_index; };
 
-void EioInstance::add_probe(eio_probe_t &probe) { m_probes.push_back(probe); }
+void EioInstance::add_probe(eio_probe_t& probe) { m_probes.push_back(probe); }
 
-std::vector<eio_probe_t> EioInstance::get_probes(eio_probe_type_t type) const {
-  std::vector<eio_probe_t> probes{};
-  for (auto &p : m_probes) {
-    if (p.type == type) {
-      probes.push_back(p);
-    }
-  }
-  return probes;
-}
+std::vector<eio_probe_t>& EioInstance::get_probes() { return m_probes; }

--- a/src/ConfigurationRS/Ocla/EioInstance.cpp
+++ b/src/ConfigurationRS/Ocla/EioInstance.cpp
@@ -3,17 +3,14 @@
 #include "ConfigurationRS/CFGCommonRS/CFGCommonRS.h"
 #include "OclaHelpers.h"
 
-EioInstance::EioInstance(uint32_t baseaddr) : m_baseaddr(baseaddr) {}
+EioInstance::EioInstance(uint32_t baseaddr, uint32_t idx)
+    : m_baseaddr(baseaddr), m_index(idx) {}
 
 EioInstance::~EioInstance() {}
 
-std::vector<eio_probe_t> EioInstance::get_input_probes() const {
-  return get_probes(eio_probe_type_t::IO_INPUT);
-}
+uint32_t EioInstance::get_baseaddr() const { return m_baseaddr; }
 
-std::vector<eio_probe_t> EioInstance::get_output_probes() const {
-  return get_probes(eio_probe_type_t::IO_OUTPUT);
-}
+uint32_t EioInstance::get_index() const { return m_index; };
 
 void EioInstance::add_probe(eio_probe_t &probe) { m_probes.push_back(probe); }
 

--- a/src/ConfigurationRS/Ocla/EioInstance.cpp
+++ b/src/ConfigurationRS/Ocla/EioInstance.cpp
@@ -8,11 +8,11 @@ EioInstance::EioInstance(uint32_t baseaddr) : m_baseaddr(baseaddr) {}
 EioInstance::~EioInstance() {}
 
 std::vector<eio_probe_t> EioInstance::get_input_probes() const {
-  return get_probes(eio_probe_type_t::INPUT);
+  return get_probes(eio_probe_type_t::IO_INPUT);
 }
 
 std::vector<eio_probe_t> EioInstance::get_output_probes() const {
-  return get_probes(eio_probe_type_t::OUTPUT);
+  return get_probes(eio_probe_type_t::IO_OUTPUT);
 }
 
 void EioInstance::add_probe(eio_probe_t &probe) { m_probes.push_back(probe); }

--- a/src/ConfigurationRS/Ocla/EioInstance.cpp
+++ b/src/ConfigurationRS/Ocla/EioInstance.cpp
@@ -7,24 +7,22 @@ EioInstance::EioInstance(uint32_t baseaddr) : m_baseaddr(baseaddr) {}
 
 EioInstance::~EioInstance() {}
 
-std::vector<eio_probe_t> EioInstance::get_input_probes()  {
-    return get_probes(eio_probe_type_t::INPUT);
+std::vector<eio_probe_t> EioInstance::get_input_probes() const {
+  return get_probes(eio_probe_type_t::INPUT);
 }
 
-std::vector<eio_probe_t> EioInstance::get_output_probes()  {
-    return get_probes(eio_probe_type_t::OUTPUT);
+std::vector<eio_probe_t> EioInstance::get_output_probes() const {
+  return get_probes(eio_probe_type_t::OUTPUT);
 }
 
-void EioInstance::add_probe(eio_probe_t &probe) {
-    m_probes.push_back(probe);
-}
+void EioInstance::add_probe(eio_probe_t &probe) { m_probes.push_back(probe); }
 
-std::vector<eio_probe_t> EioInstance::get_probes(eio_probe_type_t type) {
-    std::vector<eio_probe_t> probes{};
-    for (auto &p : m_probes) {
-        if (p.type == type) {
-            probes.push_back(p);
-        }
+std::vector<eio_probe_t> EioInstance::get_probes(eio_probe_type_t type) const {
+  std::vector<eio_probe_t> probes{};
+  for (auto &p : m_probes) {
+    if (p.type == type) {
+      probes.push_back(p);
     }
-    return probes;
+  }
+  return probes;
 }

--- a/src/ConfigurationRS/Ocla/EioInstance.h
+++ b/src/ConfigurationRS/Ocla/EioInstance.h
@@ -1,41 +1,39 @@
 #ifndef __EIOINSTANCE_H__
 #define __EIOINSTANCE_H__
 
-#include <vector>
-#include <string>
 #include <cstdint>
+#include <string>
+#include <vector>
 
-enum eio_probe_type_t {
-    INPUT,
-    OUTPUT
-};
+enum eio_probe_type_t { INPUT, OUTPUT };
 
 struct eio_signal_t {
-    std::string orig_name;
-    std::string name;
-    uint32_t bitpos;
-    uint32_t bitwidth;
-    uint32_t idx;
+  std::string orig_name;
+  std::string name;
+  uint32_t bitpos;
+  uint32_t bitwidth;
+  uint32_t idx;
 };
 
 struct eio_probe_t {
-    std::vector<eio_signal_t> signal_list;
-    eio_probe_type_t type;
-    uint32_t probe_width;
-    uint32_t idx;
+  std::vector<eio_signal_t> signal_list;
+  eio_probe_type_t type;
+  uint32_t probe_width;
+  uint32_t idx;
 };
 
 class EioInstance {
  public:
   EioInstance(uint32_t baseaddr);
   ~EioInstance();
-  std::vector<eio_probe_t> get_input_probes() ;
-  std::vector<eio_probe_t> get_output_probes() ;
+  std::vector<eio_probe_t> get_input_probes() const;
+  std::vector<eio_probe_t> get_output_probes() const;
   void add_probe(eio_probe_t &probe);
+
  private:
   uint32_t m_baseaddr;
   std::vector<eio_probe_t> m_probes;
-  std::vector<eio_probe_t> get_probes(eio_probe_type_t type);
+  std::vector<eio_probe_t> get_probes(eio_probe_type_t type) const;
 };
 
 #endif  //__EIOINSTANCE_H__

--- a/src/ConfigurationRS/Ocla/EioInstance.h
+++ b/src/ConfigurationRS/Ocla/EioInstance.h
@@ -24,16 +24,17 @@ struct eio_probe_t {
 
 class EioInstance {
  public:
-  EioInstance(uint32_t baseaddr);
+  EioInstance(uint32_t baseaddr, uint32_t index);
   ~EioInstance();
-  std::vector<eio_probe_t> get_input_probes() const;
-  std::vector<eio_probe_t> get_output_probes() const;
+  std::vector<eio_probe_t> get_probes(eio_probe_type_t type) const;
   void add_probe(eio_probe_t &probe);
+  uint32_t get_baseaddr() const;
+  uint32_t get_index() const;
 
  private:
   uint32_t m_baseaddr;
+  uint32_t m_index;
   std::vector<eio_probe_t> m_probes;
-  std::vector<eio_probe_t> get_probes(eio_probe_type_t type) const;
 };
 
 #endif  //__EIOINSTANCE_H__

--- a/src/ConfigurationRS/Ocla/EioInstance.h
+++ b/src/ConfigurationRS/Ocla/EioInstance.h
@@ -1,0 +1,41 @@
+#ifndef __EIOINSTANCE_H__
+#define __EIOINSTANCE_H__
+
+#include <vector>
+#include <string>
+#include <cstdint>
+
+enum eio_probe_type_t {
+    INPUT,
+    OUTPUT
+};
+
+struct eio_signal_t {
+    std::string orig_name;
+    std::string name;
+    uint32_t bitpos;
+    uint32_t bitwidth;
+    uint32_t idx;
+};
+
+struct eio_probe_t {
+    std::vector<eio_signal_t> signal_list;
+    eio_probe_type_t type;
+    uint32_t probe_width;
+    uint32_t idx;
+};
+
+class EioInstance {
+ public:
+  EioInstance(uint32_t baseaddr);
+  ~EioInstance();
+  std::vector<eio_probe_t> get_input_probes() ;
+  std::vector<eio_probe_t> get_output_probes() ;
+  void add_probe(eio_probe_t &probe);
+ private:
+  uint32_t m_baseaddr;
+  std::vector<eio_probe_t> m_probes;
+  std::vector<eio_probe_t> get_probes(eio_probe_type_t type);
+};
+
+#endif  //__EIOINSTANCE_H__

--- a/src/ConfigurationRS/Ocla/EioInstance.h
+++ b/src/ConfigurationRS/Ocla/EioInstance.h
@@ -17,6 +17,7 @@ struct eio_signal_t {
 
 struct eio_probe_t {
   std::vector<eio_signal_t> signal_list;
+  std::vector<uint32_t> state;
   eio_probe_type_t type;
   uint32_t probe_width;
   uint32_t idx;

--- a/src/ConfigurationRS/Ocla/EioInstance.h
+++ b/src/ConfigurationRS/Ocla/EioInstance.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-enum eio_probe_type_t { INPUT, OUTPUT };
+enum eio_probe_type_t { IO_INPUT, IO_OUTPUT };
 
 struct eio_signal_t {
   std::string orig_name;

--- a/src/ConfigurationRS/Ocla/EioInstance.h
+++ b/src/ConfigurationRS/Ocla/EioInstance.h
@@ -26,8 +26,8 @@ class EioInstance {
  public:
   EioInstance(uint32_t baseaddr, uint32_t index);
   ~EioInstance();
-  std::vector<eio_probe_t> get_probes(eio_probe_type_t type) const;
-  void add_probe(eio_probe_t &probe);
+  std::vector<eio_probe_t>& get_probes();
+  void add_probe(eio_probe_t& probe);
   uint32_t get_baseaddr() const;
   uint32_t get_index() const;
 

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -399,7 +399,7 @@ bool Ocla::get_hier_objects(uint32_t session_id, OclaDebugSession *&session,
   return true;
 }
 
-void Ocla::show_signal_table(std::vector<OclaSignal> signals_list) {
+void Ocla::show_signal_table(std::vector<OclaSignal> signal_list) {
   CFG_POST_MSG(
       "  "
       "+-------+-------------------------------------+--------------+------"
@@ -412,7 +412,7 @@ void Ocla::show_signal_table(std::vector<OclaSignal> signals_list) {
       "+-------+-------------------------------------+--------------+------"
       "--------+");
 
-  for (auto &sig : signals_list) {
+  for (auto &sig : signal_list) {
     CFG_POST_MSG("  | %5d | %-35s | %-12d | %-12d |", sig.get_index(),
                  sig.get_name().c_str(), sig.get_bitpos(), sig.get_bitwidth());
   }
@@ -515,6 +515,30 @@ void Ocla::show_info() {
 
     CFG_POST_MSG(" ");
   }
+
+  // show eio info
+  for (auto &eio : session->get_eio_instances()) {
+    CFG_POST_MSG("EIO:");
+    for (auto &probe : eio.get_input_probes()) {
+      CFG_POST_MSG("  In Probe %d", probe.idx);
+      show_eio_signal_table(probe.signal_list);
+    }
+    for (auto &probe : eio.get_output_probes()) {
+      CFG_POST_MSG("  Out Probe %d", probe.idx);
+      show_eio_signal_table(probe.signal_list);
+    }
+    CFG_POST_MSG(" ");
+  }
+}
+
+void Ocla::show_eio_signal_table(std::vector<eio_signal_t> &signal_list) {
+  CFG_POST_MSG("  +-------+-----------------------+--------------+");
+  CFG_POST_MSG("  | Index | Signal Name           | Bitwidth     |");
+  CFG_POST_MSG("  +-------+-----------------------+--------------+");
+  for (auto &s : signal_list) {
+    CFG_POST_MSG("  | %5d | %-21s | %-12d |", s.idx, s.name.c_str(), s.bitwidth);
+  }
+  CFG_POST_MSG("  +-------+-----------------------+--------------+");
 }
 
 void Ocla::show_instance_info() {

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -520,25 +520,37 @@ void Ocla::show_info() {
   for (auto &eio : session->get_eio_instances()) {
     CFG_POST_MSG("EIO:");
     for (auto &probe : eio.get_input_probes()) {
-      CFG_POST_MSG("  In Probe %d", probe.idx);
+      CFG_POST_MSG("  In-Probe %d", probe.idx);
       show_eio_signal_table(probe.signal_list);
     }
     for (auto &probe : eio.get_output_probes()) {
-      CFG_POST_MSG("  Out Probe %d", probe.idx);
+      CFG_POST_MSG("  Out-Probe %d", probe.idx);
       show_eio_signal_table(probe.signal_list);
     }
+    CFG_POST_MSG(" ");
+    // print usage informat requested by IP team
+    CFG_POST_MSG("  NOTES");
+    CFG_POST_MSG(
+        "    Use 'loop' & 'duration' options to repeatedly read the state of "
+        "the input signal");
+    CFG_POST_MSG("    for specific number of times.");
     CFG_POST_MSG(" ");
   }
 }
 
 void Ocla::show_eio_signal_table(std::vector<eio_signal_t> &signal_list) {
-  CFG_POST_MSG("  +-------+-----------------------+--------------+");
-  CFG_POST_MSG("  | Index | Signal Name           | Bitwidth     |");
-  CFG_POST_MSG("  +-------+-----------------------+--------------+");
+  CFG_POST_MSG(
+      "  +-------+-------------------------------------+--------------+");
+  CFG_POST_MSG(
+      "  | Index | Signal Name                         | Bitwidth     |");
+  CFG_POST_MSG(
+      "  +-------+-------------------------------------+--------------+");
   for (auto &s : signal_list) {
-    CFG_POST_MSG("  | %5d | %-21s | %-12d |", s.idx, s.name.c_str(), s.bitwidth);
+    CFG_POST_MSG("  | %5d | %-35s | %-12d |", s.idx, s.name.c_str(),
+                 s.bitwidth);
   }
-  CFG_POST_MSG("  +-------+-----------------------+--------------+");
+  CFG_POST_MSG(
+      "  +-------+-------------------------------------+--------------+");
 }
 
 void Ocla::show_instance_info() {

--- a/src/ConfigurationRS/Ocla/Ocla.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla.cpp
@@ -1068,7 +1068,7 @@ bool Ocla::get_io(std::vector<std::string> signal_names,
   EioIP eio{m_adapter, instance->get_baseaddr()};
   auto result = eio.read((msb_pos / 32) + 1);
   for (auto &s : output_list) {
-    std::vector<uint32_t> buf{0, 0};
+    std::vector<uint32_t> buf(((s.bitwidth - 1) / 32) + 1, 0);
     eio_value_t value{};
     CFG_copy_bits_vec32(result.data(), s.bitpos, buf.data(), 0, s.bitwidth);
     value.signal_name = s.name;

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -30,6 +30,11 @@ struct oc_waveform_t {
   uint32_t domain_id;
 };
 
+struct eio_value_t {
+  std::string signal_name;
+  uint64_t value;
+};
+
 class Ocla {
  public:
   Ocla(OclaJtagAdapter *adapter);
@@ -48,6 +53,10 @@ class Ocla {
   bool get_status(uint32_t domain_id, uint32_t &status);
   bool start(uint32_t domain_id);
   void start_session(std::string filepath);
+  bool set_io(std::vector<std::string> signal_names,
+              std::vector<uint64_t> values);
+  bool get_io(std::vector<std::string> signal_names,
+              std::vector<eio_value_t> &values);
   void stop_session();
   void show_info();
   void show_instance_info();
@@ -61,7 +70,11 @@ class Ocla {
                         uint32_t probe_id = 0, OclaProbe **probe = nullptr,
                         std::string signal_name = "",
                         OclaSignal **signal = nullptr);
-  void show_signal_table(std::vector<OclaSignal> signal_list);
+  bool get_eio_signals(OclaDebugSession &session,
+                       std::vector<std::string> signal_names,
+                       eio_probe_type_t probe_type,
+                       std::vector<eio_signal_t> &output_signals);
+  void show_signal_table(std::vector<OclaSignal> &signal_list);
   void show_eio_signal_table(std::vector<eio_signal_t> &signal_list);
   void program(OclaDomain *domain);
   bool verify(OclaDebugSession *session);

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -61,7 +61,8 @@ class Ocla {
                         uint32_t probe_id = 0, OclaProbe **probe = nullptr,
                         std::string signal_name = "",
                         OclaSignal **signal = nullptr);
-  void show_signal_table(std::vector<OclaSignal> signals_list);
+  void show_signal_table(std::vector<OclaSignal> signal_list);
+  void show_eio_signal_table(std::vector<eio_signal_t> &signal_list);
   void program(OclaDomain *domain);
   bool verify(OclaDebugSession *session);
   std::string format_signal_name(oc_trigger_t &trig);

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -56,7 +56,7 @@ class Ocla {
   bool set_io(std::vector<std::string> signal_names,
               std::vector<uint64_t> values);
   bool get_io(std::vector<std::string> signal_names,
-              std::vector<eio_value_t> &values);
+              std::vector<eio_value_t> &output);
   void stop_session();
   void show_info();
   void show_instance_info();

--- a/src/ConfigurationRS/Ocla/Ocla.h
+++ b/src/ConfigurationRS/Ocla/Ocla.h
@@ -65,19 +65,25 @@ class Ocla {
   static std::vector<OclaDebugSession> m_sessions;
   OclaJtagAdapter *m_adapter;
 
+  bool get_session(uint32_t session_id, OclaDebugSession *&session);
   bool get_hier_objects(uint32_t session_id, OclaDebugSession *&session,
                         uint32_t domain_id = 0, OclaDomain **domain = nullptr,
                         uint32_t probe_id = 0, OclaProbe **probe = nullptr,
                         std::string signal_name = "",
                         OclaSignal **signal = nullptr);
-  bool get_eio_signals(OclaDebugSession &session,
-                       std::vector<std::string> signal_names,
-                       eio_probe_type_t probe_type,
-                       std::vector<eio_signal_t> &output_signals);
+  bool get_eio_hier_objects(uint32_t session_id, OclaDebugSession *&session,
+                            uint32_t instance_index = 0,
+                            EioInstance **instance = nullptr,
+                            uint32_t probe_id = 0,
+                            eio_probe_type_t probe_type = IO_INPUT,
+                            eio_probe_t **probe = nullptr);
   void show_signal_table(std::vector<OclaSignal> &signal_list);
   void show_eio_signal_table(std::vector<eio_signal_t> &signal_list);
   void program(OclaDomain *domain);
   bool verify(OclaDebugSession *session);
+  bool find_eio_signals(std::vector<eio_signal_t> &signal_list,
+                        std::vector<std::string> signal_names,
+                        std::vector<eio_signal_t> &output_list);
   std::string format_signal_name(oc_trigger_t &trig);
 };
 

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
@@ -59,7 +59,8 @@ bool OclaDebugSession::load(std::string filepath,
   try {
     nlohmann::json json = nlohmann::json::parse(json_str);
     if (!json.contains("eio") && !json.contains("ocla")) {
-      error_messages.push_back("Debug information contains no OCLA nor EIO information");
+      error_messages.push_back(
+          "Debug information contains no OCLA nor EIO information");
       return false;
     }
     if (json.contains("ocla")) {
@@ -71,7 +72,7 @@ bool OclaDebugSession::load(std::string filepath,
       if (!parse_eio(json, error_messages)) {
         return false;
       }
-    }   
+    }
   } catch (const nlohmann::detail::exception &e) {
     CFG_ASSERT_MSG(false, e.what());
   }
@@ -91,7 +92,8 @@ std::vector<EioInstance> OclaDebugSession::get_eio_instances() {
   return m_eio_instances;
 }
 
-bool OclaDebugSession::parse_eio(nlohmann::json json, std::vector<std::string>& error_messages) {
+bool OclaDebugSession::parse_eio(nlohmann::json json,
+                                 std::vector<std::string> &error_messages) {
   nlohmann::json eio = json.at("eio");
   uint32_t input_probe_width = eio.at("Input_Probe_Width");
   uint32_t output_probe_width = eio.at("Output_Probe_Width");
@@ -101,14 +103,14 @@ bool OclaDebugSession::parse_eio(nlohmann::json json, std::vector<std::string>& 
   EioInstance instance{eio.at("addr")};
 
   if (eio.contains("probes_in")) {
-    // NOTE: create one input probe. only 1 input probe is supported at current version.
-    // multiple input probes will be supported in the future.
+    // NOTE: create one input probe. only 1 input probe is supported at current
+    // version. multiple input probes will be supported in the future.
     eio_probe_t probe{};
     probe.type = eio_probe_type_t::INPUT;
     probe.probe_width = 0;
     probe.idx = 1;
     signal_index = 1;
-        
+
     // parse probe signals
     for (auto &p : eio.at("probes_in")) {
       eio_signal_t sig{};
@@ -120,9 +122,12 @@ bool OclaDebugSession::parse_eio(nlohmann::json json, std::vector<std::string>& 
       probe.signal_list.push_back(sig);
     }
 
-    // sanity check to see if parsed total signal width matches Input_Probe_Width
+    // sanity check to see if parsed total signal width matches
+    // Input_Probe_Width
     if (probe.probe_width != input_probe_width) {
-      error_messages.push_back("EIO: Input probe width mismatched (expect=" + std::to_string(input_probe_width) + ", actual=" + std::to_string(probe.probe_width) + ")");
+      error_messages.push_back("EIO: Input probe width mismatched (expect=" +
+                               std::to_string(input_probe_width) + ", actual=" +
+                               std::to_string(probe.probe_width) + ")");
       return false;
     }
 
@@ -130,14 +135,14 @@ bool OclaDebugSession::parse_eio(nlohmann::json json, std::vector<std::string>& 
   }
 
   if (eio.contains("probes_out")) {
-    // NOTE: create one output probe. only 1 output probe is supported at current version.
-    // multiple output probes will be supported in the future.
+    // NOTE: create one output probe. only 1 output probe is supported at
+    // current version. multiple output probes will be supported in the future.
     eio_probe_t probe{};
     probe.type = eio_probe_type_t::OUTPUT;
     probe.probe_width = 0;
     probe.idx = 1;
     signal_index = 1;
-        
+
     // parse probe signals
     for (auto &p : eio.at("probes_out")) {
       eio_signal_t sig{};
@@ -149,9 +154,13 @@ bool OclaDebugSession::parse_eio(nlohmann::json json, std::vector<std::string>& 
       probe.signal_list.push_back(sig);
     }
 
-    // sanity check to see if parsed total signal width matches Output_Probe_Width
+    // sanity check to see if parsed total signal width matches
+    // Output_Probe_Width
     if (probe.probe_width != output_probe_width) {
-      error_messages.push_back("EIO: Output probe width mismatched (expect=" + std::to_string(output_probe_width) + ", actual=" + std::to_string(probe.probe_width) + ")");
+      error_messages.push_back("EIO: Output probe width mismatched (expect=" +
+                               std::to_string(output_probe_width) +
+                               ", actual=" + std::to_string(probe.probe_width) +
+                               ")");
       return false;
     }
 
@@ -163,7 +172,7 @@ bool OclaDebugSession::parse_eio(nlohmann::json json, std::vector<std::string>& 
 }
 
 bool OclaDebugSession::parse_ocla(nlohmann::json json,
-                             std::vector<std::string> &error_messages) {
+                                  std::vector<std::string> &error_messages) {
   nlohmann::json ocla_debug_subsystem = json.at("ocla_debug_subsystem");
   nlohmann::json ocla_list = json.at("ocla");
   std::vector<OclaDomain> deferred_list{};
@@ -183,7 +192,7 @@ bool OclaDebugSession::parse_ocla(nlohmann::json json,
     // sanity check: duplicate instance index
     if (indexes.find(ocla.at("INDEX")) != indexes.end()) {
       error_messages.push_back("Duplicate instance index " +
-                                std::to_string((uint32_t)ocla.at("INDEX")));
+                               std::to_string((uint32_t)ocla.at("INDEX")));
       res = false;
       break;
     }
@@ -325,8 +334,9 @@ bool OclaDebugSession::parse_ocla(nlohmann::json json,
   return res;
 }
 
-bool OclaDebugSession::parse_eio_signal(std::string signal_str, eio_signal_t &signal,
-                                    std::vector<std::string> &error_messages) {
+bool OclaDebugSession::parse_eio_signal(
+    std::string signal_str, eio_signal_t &signal,
+    std::vector<std::string> &error_messages) {
   std::string signal_name = "";
   uint32_t bit_start = 0;
   uint32_t bit_end = 0;
@@ -336,11 +346,12 @@ bool OclaDebugSession::parse_eio_signal(std::string signal_str, eio_signal_t &si
   auto patid = CFG_parse_signal(signal_str, signal_name, bit_start, bit_end,
                                 bit_width, bit_value);
   switch (patid) {
-    case OCLA_SIGNAL_PATTERN_1: // pattern 1: count[13:2]
-    case OCLA_SIGNAL_PATTERN_3: // pattern 3: s_axil_awprot[0]
-    case OCLA_SIGNAL_PATTERN_5: // pattern 5: s_axil_bready
+    case OCLA_SIGNAL_PATTERN_1:  // pattern 1: count[13:2]
+    case OCLA_SIGNAL_PATTERN_3:  // pattern 3: s_axil_awprot[0]
+    case OCLA_SIGNAL_PATTERN_5:  // pattern 5: s_axil_bready
       if (bit_end < bit_start) {
-        error_messages.push_back("EIO: Invalid bit position '" + signal_str + "'");
+        error_messages.push_back("EIO: Invalid bit position '" + signal_str +
+                                 "'");
         return false;
       }
       signal.orig_name = signal_str;
@@ -349,16 +360,17 @@ bool OclaDebugSession::parse_eio_signal(std::string signal_str, eio_signal_t &si
       signal.bitwidth = bit_end - bit_start + 1;
       break;
     default:
-      error_messages.push_back("EIO: Invalid signal name format '" + signal_str +
-                               "'");
-      return false;                               
-  }                                    
-                                      
+      error_messages.push_back("EIO: Invalid signal name format '" +
+                               signal_str + "'");
+      return false;
+  }
+
   return true;
 }
 
-bool OclaDebugSession::parse_ocla_signal(std::string signal_str, OclaSignal &signal,
-                                    std::vector<std::string> &error_messages) {
+bool OclaDebugSession::parse_ocla_signal(
+    std::string signal_str, OclaSignal &signal,
+    std::vector<std::string> &error_messages) {
   std::string signal_name = "";
   uint32_t bit_start = 0;
   uint32_t bit_end = 0;

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
@@ -100,7 +100,7 @@ bool OclaDebugSession::parse_eio(nlohmann::json json,
   uint32_t signal_index;
 
   // create one eio instance. only 1 instance is supported at current version
-  EioInstance instance{eio.at("addr")};
+  EioInstance instance{eio.at("addr"), 1};
 
   if (eio.contains("probes_in")) {
     // NOTE: create one input probe. only 1 input probe is supported at current

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
@@ -88,7 +88,7 @@ void OclaDebugSession::unload() {
   m_loaded = false;
 }
 
-std::vector<EioInstance> OclaDebugSession::get_eio_instances() {
+std::vector<EioInstance> &OclaDebugSession::get_eio_instances() {
   return m_eio_instances;
 }
 

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
@@ -5,7 +5,6 @@
 #include "BitAssembler/BitAssembler_mgr.h"
 #include "ConfigurationRS/CFGCommonRS/CFGCommonRS.h"
 #include "OclaHelpers.h"
-#include "nlohmann_json/json.hpp"
 
 OclaDebugSession::OclaDebugSession() : m_loaded(false) {}
 
@@ -51,14 +50,30 @@ bool OclaDebugSession::load(std::string filepath,
     unload();
   }
 
-  std::string ocla_str = BitAssembler_MGR::get_ocla_design(filepath);
-  if (ocla_str.empty()) {
+  std::string json_str = BitAssembler_MGR::get_ocla_design(filepath);
+  if (json_str.empty()) {
     error_messages.push_back("No OCLA debug information found");
     return false;
   }
 
-  if (!parse(ocla_str, error_messages)) {
-    return false;
+  try {
+    nlohmann::json json = nlohmann::json::parse(json_str);
+    if (!json.contains("eio") && !json.contains("ocla")) {
+      error_messages.push_back("Debug information contains no OCLA nor EIO information");
+      return false;
+    }
+    if (json.contains("ocla")) {
+      if (!parse_ocla(json, error_messages)) {
+        return false;
+      }
+    }
+    if (json.contains("eio")) {
+      if (!parse_eio(json, error_messages)) {
+        return false;
+      }
+    }   
+  } catch (const nlohmann::detail::exception &e) {
+    CFG_ASSERT_MSG(false, e.what());
   }
 
   m_filepath = filepath;
@@ -72,175 +87,277 @@ void OclaDebugSession::unload() {
   m_loaded = false;
 }
 
-bool OclaDebugSession::parse(std::string ocla_str,
-                             std::vector<std::string> &error_messages) {
-  bool res = true;
-  try {
-    nlohmann::json json = nlohmann::json::parse(ocla_str);
-    nlohmann::json ocla_debug_subsystem = json.at("ocla_debug_subsystem");
-    nlohmann::json ocla_list = json.at("ocla");
-    std::vector<OclaDomain> deferred_list{};
-    std::map<uint32_t, int> indexes{};
-    uint32_t probes_sum = 0;
-    bool single = false;
+std::vector<EioInstance> OclaDebugSession::get_eio_instances() {
+  return m_eio_instances;
+}
 
-    if (ocla_debug_subsystem.at("Sampling_Clk") == "SINGLE") {
-      // create one single domain object for all ocla instances for single
-      // sampling clock setting
-      m_clock_domains.push_back(OclaDomain{oc_domain_type_t::NATIVE, 1});
-      single = true;
+bool OclaDebugSession::parse_eio(nlohmann::json json, std::vector<std::string>& error_messages) {
+  nlohmann::json eio = json.at("eio");
+  uint32_t input_probe_width = eio.at("Input_Probe_Width");
+  uint32_t output_probe_width = eio.at("Output_Probe_Width");
+  uint32_t signal_index;
+
+  // create one eio instance. only 1 instance is supported at current version
+  EioInstance instance{eio.at("addr")};
+
+  if (eio.contains("probes_in")) {
+    // NOTE: create one input probe. only 1 input probe is supported at current version.
+    // multiple input probes will be supported in the future.
+    eio_probe_t probe{};
+    probe.type = eio_probe_type_t::INPUT;
+    probe.probe_width = 0;
+    probe.idx = 1;
+    signal_index = 1;
+        
+    // parse probe signals
+    for (auto &p : eio.at("probes_in")) {
+      eio_signal_t sig{};
+      if (!parse_eio_signal(p, sig, error_messages)) {
+        return false;
+      }
+      sig.idx = signal_index++;
+      probe.probe_width += sig.bitwidth;
+      probe.signal_list.push_back(sig);
     }
 
-    for (const auto &ocla : ocla_list) {
-      // sanity check: duplicate instance index
-      if (indexes.find(ocla.at("INDEX")) != indexes.end()) {
-        error_messages.push_back("Duplicate instance index " +
-                                 std::to_string((uint32_t)ocla.at("INDEX")));
+    // sanity check to see if parsed total signal width matches Input_Probe_Width
+    if (probe.probe_width != input_probe_width) {
+      error_messages.push_back("EIO: Input probe width mismatched (expect=" + std::to_string(input_probe_width) + ", actual=" + std::to_string(probe.probe_width) + ")");
+      return false;
+    }
+
+    instance.add_probe(probe);
+  }
+
+  if (eio.contains("probes_out")) {
+    // NOTE: create one output probe. only 1 output probe is supported at current version.
+    // multiple output probes will be supported in the future.
+    eio_probe_t probe{};
+    probe.type = eio_probe_type_t::OUTPUT;
+    probe.probe_width = 0;
+    probe.idx = 1;
+    signal_index = 1;
+        
+    // parse probe signals
+    for (auto &p : eio.at("probes_out")) {
+      eio_signal_t sig{};
+      if (!parse_eio_signal(p, sig, error_messages)) {
+        return false;
+      }
+      sig.idx = signal_index++;
+      probe.probe_width += sig.bitwidth;
+      probe.signal_list.push_back(sig);
+    }
+
+    // sanity check to see if parsed total signal width matches Output_Probe_Width
+    if (probe.probe_width != output_probe_width) {
+      error_messages.push_back("EIO: Output probe width mismatched (expect=" + std::to_string(output_probe_width) + ", actual=" + std::to_string(probe.probe_width) + ")");
+      return false;
+    }
+
+    instance.add_probe(probe);
+  }
+
+  m_eio_instances.push_back(instance);
+  return true;
+}
+
+bool OclaDebugSession::parse_ocla(nlohmann::json json,
+                             std::vector<std::string> &error_messages) {
+  nlohmann::json ocla_debug_subsystem = json.at("ocla_debug_subsystem");
+  nlohmann::json ocla_list = json.at("ocla");
+  std::vector<OclaDomain> deferred_list{};
+  std::map<uint32_t, int> indexes{};
+  uint32_t probes_sum = 0;
+  bool single = false;
+  bool res = true;
+
+  if (ocla_debug_subsystem.at("Sampling_Clk") == "SINGLE") {
+    // create one single domain object for all ocla instances for single
+    // sampling clock setting
+    m_clock_domains.push_back(OclaDomain{oc_domain_type_t::NATIVE, 1});
+    single = true;
+  }
+
+  for (const auto &ocla : ocla_list) {
+    // sanity check: duplicate instance index
+    if (indexes.find(ocla.at("INDEX")) != indexes.end()) {
+      error_messages.push_back("Duplicate instance index " +
+                                std::to_string((uint32_t)ocla.at("INDEX")));
+      res = false;
+      break;
+    }
+
+    // parse instance info
+    OclaInstance instance{ocla.at("IP_TYPE"),      ocla.at("IP_VERSION"),
+                          ocla.at("IP_ID"),        ocla.at("MEM_DEPTH"),
+                          ocla.at("NO_OF_PROBES"), ocla.at("addr"),
+                          ocla.at("INDEX")};
+
+    // insert into index map for duplicate check
+    indexes[instance.get_index()] = 1;
+
+    // accumulate no of probes for all instances
+    probes_sum += instance.get_num_of_probes();
+
+    // parse signal info
+    std::vector<OclaSignal> signals{};
+    uint32_t bitpos = 0;
+    uint32_t total_bitwidth = 0;
+    for (auto const &elem : ocla.at("probes")) {
+      OclaSignal sig{};
+      if (!parse_ocla_signal(elem, sig, error_messages)) {
         res = false;
         break;
       }
+      sig.set_bitpos(bitpos);
+      bitpos += sig.get_bitwidth();
+      total_bitwidth += sig.get_bitwidth();
+      signals.push_back(sig);
+    }
 
-      // parse instance info
-      OclaInstance instance{ocla.at("IP_TYPE"),      ocla.at("IP_VERSION"),
-                            ocla.at("IP_ID"),        ocla.at("MEM_DEPTH"),
-                            ocla.at("NO_OF_PROBES"), ocla.at("addr"),
-                            ocla.at("INDEX")};
+    // break the loop in case probes parsing failed above
+    if (!res) {
+      break;
+    }
 
-      // insert into index map for duplicate check
-      indexes[instance.get_index()] = 1;
+    // sanity check: total width of probes equals to no. of probes of the
+    // instance
+    if (total_bitwidth != instance.get_num_of_probes()) {
+      error_messages.push_back(
+          "Instance " + std::to_string(instance.get_index()) +
+          " total probes width mismatched (expect=" +
+          std::to_string(instance.get_num_of_probes()) +
+          ", actual=" + std::to_string(total_bitwidth) + ")");
+      res = false;
+      break;
+    }
 
-      // accumulate no of probes for all instances
-      probes_sum += instance.get_num_of_probes();
+    // parse probe info
+    if (ocla.at("probe_info").size() > 0) {
+      // native probe
+      uint32_t signal_index = 1;
 
-      // parse signal info
-      std::vector<OclaSignal> signals{};
-      uint32_t bitpos = 0;
-      uint32_t total_bitwidth = 0;
-      for (auto const &elem : ocla.at("probes")) {
-        OclaSignal sig{};
-        if (!parse_signal(elem, sig, error_messages)) {
-          res = false;
-          break;
-        }
-        sig.set_bitpos(bitpos);
-        bitpos += sig.get_bitwidth();
-        total_bitwidth += sig.get_bitwidth();
-        signals.push_back(sig);
+      if (!single) {
+        // create a domain object for each ocla instance for multiple sampling
+        // clock setting
+        m_clock_domains.push_back(OclaDomain{
+            oc_domain_type_t::NATIVE, (uint32_t)m_clock_domains.size() + 1});
       }
 
-      // break the loop in case probes parsing failed above
-      if (!res) {
-        break;
-      }
+      // get target domain object to work on
+      OclaDomain &domain = m_clock_domains[m_clock_domains.size() - 1];
+      domain.add_instance(instance);
 
-      // sanity check: total width of probes equals to no. of probes of the
-      // instance
-      if (total_bitwidth != instance.get_num_of_probes()) {
-        error_messages.push_back(
-            "Instance " + std::to_string(instance.get_index()) +
-            " total probes width mismatched (expect=" +
-            std::to_string(instance.get_num_of_probes()) +
-            ", actual=" + std::to_string(total_bitwidth) + ")");
-        res = false;
-        break;
-      }
-
-      // parse probe info
-      if (ocla.at("probe_info").size() > 0) {
-        // native probe
-        uint32_t signal_index = 1;
-
-        if (!single) {
-          // create a domain object for each ocla instance for multiple sampling
-          // clock setting
-          m_clock_domains.push_back(OclaDomain{
-              oc_domain_type_t::NATIVE, (uint32_t)m_clock_domains.size() + 1});
-        }
-
-        // get target domain object to work on
-        OclaDomain &domain = m_clock_domains[m_clock_domains.size() - 1];
-        domain.add_instance(instance);
-
-        // create probes
-        uint32_t total_probe_width = 0;
-        for (auto const &elem : ocla.at("probe_info")) {
-          uint32_t probe_index = elem.at("index");
-          uint32_t offset = elem.at("offset");
-          uint32_t width = elem.at("width");
-          total_probe_width += width;
-          OclaProbe probe{probe_index + 1};
-          probe.set_instance_index(instance.get_index());
-          for (auto &sig : signals) {
-            // add signals
-            if (sig.get_bitpos() >= offset &&
-                sig.get_bitpos() < (offset + width)) {
-              sig.set_index(signal_index++);
-              probe.add_signal(sig);
-            }
-          }
-          domain.add_probe(probe);
-        }
-
-        // sanity check: total width of probe_info equals to no. of probes of
-        // the instance
-        if (total_probe_width != instance.get_num_of_probes()) {
-          error_messages.push_back(
-              "Instance " + std::to_string(instance.get_index()) +
-              " total probe_info width mismatched (expect=" +
-              std::to_string(instance.get_num_of_probes()) +
-              ", actual=" + std::to_string(total_probe_width) + ")");
-          res = false;
-          break;
-        }
-      } else {
-        // axi probe
-        uint32_t signal_index = 1;
-        OclaDomain domain{oc_domain_type_t::AXI};
-        domain.add_instance(instance);
-        OclaProbe probe{1};
+      // create probes
+      uint32_t total_probe_width = 0;
+      for (auto const &elem : ocla.at("probe_info")) {
+        uint32_t probe_index = elem.at("index");
+        uint32_t offset = elem.at("offset");
+        uint32_t width = elem.at("width");
+        total_probe_width += width;
+        OclaProbe probe{probe_index + 1};
         probe.set_instance_index(instance.get_index());
         for (auto &sig : signals) {
           // add signals
-          sig.set_index(signal_index++);
-          probe.add_signal(sig);
+          if (sig.get_bitpos() >= offset &&
+              sig.get_bitpos() < (offset + width)) {
+            sig.set_index(signal_index++);
+            probe.add_signal(sig);
+          }
         }
         domain.add_probe(probe);
-        // defer adding axi domains as it should always stay at the bottom of
-        // the clock domain list
-        deferred_list.push_back(domain);
       }
-    }
 
-    if (res) {
-      // sanity check: total no. of probes equals to Probes_Sum in debug info
-      if (probes_sum != ocla_debug_subsystem.at("Probes_Sum")) {
+      // sanity check: total width of probe_info equals to no. of probes of
+      // the instance
+      if (total_probe_width != instance.get_num_of_probes()) {
         error_messages.push_back(
-            "Total sum of all probes mismatched (expect=" +
-            std::to_string((uint32_t)ocla_debug_subsystem.at("Probes_Sum")) +
-            ", actual=" + std::to_string(probes_sum) + ")");
+            "Instance " + std::to_string(instance.get_index()) +
+            " total probe_info width mismatched (expect=" +
+            std::to_string(instance.get_num_of_probes()) +
+            ", actual=" + std::to_string(total_probe_width) + ")");
         res = false;
-      }
-    }
-
-    if (res) {
-      // insert deferred clock domains (axi domain)
-      if (!deferred_list.empty()) {
-        for (auto &elem : deferred_list) {
-          elem.set_index((uint32_t)m_clock_domains.size() + 1);
-          m_clock_domains.push_back(elem);
-        }
+        break;
       }
     } else {
-      m_clock_domains.clear();
+      // axi probe
+      uint32_t signal_index = 1;
+      OclaDomain domain{oc_domain_type_t::AXI};
+      domain.add_instance(instance);
+      OclaProbe probe{1};
+      probe.set_instance_index(instance.get_index());
+      for (auto &sig : signals) {
+        // add signals
+        sig.set_index(signal_index++);
+        probe.add_signal(sig);
+      }
+      domain.add_probe(probe);
+      // defer adding axi domains as it should always stay at the bottom of
+      // the clock domain list
+      deferred_list.push_back(domain);
     }
-  } catch (const nlohmann::detail::exception &e) {
-    CFG_ASSERT_MSG(false, e.what());
+  }
+
+  if (res) {
+    // sanity check: total no. of probes equals to Probes_Sum in debug info
+    if (probes_sum != ocla_debug_subsystem.at("Probes_Sum")) {
+      error_messages.push_back(
+          "Total sum of all probes mismatched (expect=" +
+          std::to_string((uint32_t)ocla_debug_subsystem.at("Probes_Sum")) +
+          ", actual=" + std::to_string(probes_sum) + ")");
+      res = false;
+    }
+  }
+
+  if (res) {
+    // insert deferred clock domains (axi domain)
+    if (!deferred_list.empty()) {
+      for (auto &elem : deferred_list) {
+        elem.set_index((uint32_t)m_clock_domains.size() + 1);
+        m_clock_domains.push_back(elem);
+      }
+    }
+  } else {
+    m_clock_domains.clear();
   }
 
   return res;
 }
 
-bool OclaDebugSession::parse_signal(std::string signal_str, OclaSignal &signal,
+bool OclaDebugSession::parse_eio_signal(std::string signal_str, eio_signal_t &signal,
+                                    std::vector<std::string> &error_messages) {
+  std::string signal_name = "";
+  uint32_t bit_start = 0;
+  uint32_t bit_end = 0;
+  uint32_t bit_width = 0;
+  uint32_t bit_value = 0;
+
+  auto patid = CFG_parse_signal(signal_str, signal_name, bit_start, bit_end,
+                                bit_width, bit_value);
+  switch (patid) {
+    case OCLA_SIGNAL_PATTERN_1: // pattern 1: count[13:2]
+    case OCLA_SIGNAL_PATTERN_3: // pattern 3: s_axil_awprot[0]
+    case OCLA_SIGNAL_PATTERN_5: // pattern 5: s_axil_bready
+      if (bit_end < bit_start) {
+        error_messages.push_back("EIO: Invalid bit position '" + signal_str + "'");
+        return false;
+      }
+      signal.orig_name = signal_str;
+      signal.name = signal_name;
+      signal.bitpos = bit_start;
+      signal.bitwidth = bit_end - bit_start + 1;
+      break;
+    default:
+      error_messages.push_back("EIO: Invalid signal name format '" + signal_str +
+                               "'");
+      return false;                               
+  }                                    
+                                      
+  return true;
+}
+
+bool OclaDebugSession::parse_ocla_signal(std::string signal_str, OclaSignal &signal,
                                     std::vector<std::string> &error_messages) {
   std::string signal_name = "";
   uint32_t bit_start = 0;

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.cpp
@@ -106,7 +106,7 @@ bool OclaDebugSession::parse_eio(nlohmann::json json,
     // NOTE: create one input probe. only 1 input probe is supported at current
     // version. multiple input probes will be supported in the future.
     eio_probe_t probe{};
-    probe.type = eio_probe_type_t::INPUT;
+    probe.type = eio_probe_type_t::IO_INPUT;
     probe.probe_width = 0;
     probe.idx = 1;
     signal_index = 1;
@@ -138,7 +138,7 @@ bool OclaDebugSession::parse_eio(nlohmann::json json,
     // NOTE: create one output probe. only 1 output probe is supported at
     // current version. multiple output probes will be supported in the future.
     eio_probe_t probe{};
-    probe.type = eio_probe_type_t::OUTPUT;
+    probe.type = eio_probe_type_t::IO_OUTPUT;
     probe.probe_width = 0;
     probe.idx = 1;
     signal_index = 1;

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.h
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.h
@@ -32,7 +32,7 @@ class OclaDebugSession {
   ~OclaDebugSession();
   std::vector<OclaDomain>& get_clock_domains();
   std::vector<OclaInstance> get_instances();
-  std::vector<EioInstance> get_eio_instances();
+  std::vector<EioInstance>& get_eio_instances();
   std::vector<OclaProbe> get_probes(uint32_t instance_index);
   std::string get_filepath() const;
   bool is_loaded() const;

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.h
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.h
@@ -20,10 +20,11 @@ class OclaDebugSession {
   std::string m_filepath;
   bool m_loaded;
   bool parse_ocla_signal(std::string signal_str, OclaSignal& signal,
-                    std::vector<std::string>& error_messages);
-  bool parse_ocla(nlohmann::json json, std::vector<std::string>& error_messages);
+                         std::vector<std::string>& error_messages);
+  bool parse_ocla(nlohmann::json json,
+                  std::vector<std::string>& error_messages);
   bool parse_eio_signal(std::string signal_str, eio_signal_t& signal,
-                    std::vector<std::string>& error_messages);
+                        std::vector<std::string>& error_messages);
   bool parse_eio(nlohmann::json json, std::vector<std::string>& error_messages);
 
  public:

--- a/src/ConfigurationRS/Ocla/OclaDebugSession.h
+++ b/src/ConfigurationRS/Ocla/OclaDebugSession.h
@@ -5,26 +5,33 @@
 #include <string>
 #include <vector>
 
+#include "EioInstance.h"
 #include "OclaDomain.h"
 #include "OclaIP.h"
 #include "OclaInstance.h"
 #include "OclaProbe.h"
 #include "OclaSignal.h"
+#include "nlohmann_json/json.hpp"
 
 class OclaDebugSession {
  private:
   std::vector<OclaDomain> m_clock_domains;
+  std::vector<EioInstance> m_eio_instances;
   std::string m_filepath;
   bool m_loaded;
-  bool parse_signal(std::string signal_str, OclaSignal& signal,
+  bool parse_ocla_signal(std::string signal_str, OclaSignal& signal,
                     std::vector<std::string>& error_messages);
-  bool parse(std::string ocla_str, std::vector<std::string>& error_messages);
+  bool parse_ocla(nlohmann::json json, std::vector<std::string>& error_messages);
+  bool parse_eio_signal(std::string signal_str, eio_signal_t& signal,
+                    std::vector<std::string>& error_messages);
+  bool parse_eio(nlohmann::json json, std::vector<std::string>& error_messages);
 
  public:
   OclaDebugSession();
   ~OclaDebugSession();
   std::vector<OclaDomain>& get_clock_domains();
   std::vector<OclaInstance> get_instances();
+  std::vector<EioInstance> get_eio_instances();
   std::vector<OclaProbe> get_probes(uint32_t instance_index);
   std::string get_filepath() const;
   bool is_loaded() const;

--- a/src/ConfigurationRS/Ocla/OclaHelpers.cpp
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.cpp
@@ -95,6 +95,15 @@ void CFG_copy_bits_vec32(uint32_t* data, uint32_t pos, uint32_t* output,
   }
 }
 
+std::vector<uint32_t> CFG_convert_u64_to_vec_u32(uint64_t value) {
+  return {uint32_t(value), uint32_t(value >> 32)};
+}
+
+uint64_t CFG_convert_vec_u32_to_u64(std::vector<uint32_t> values) {
+  CFG_ASSERT(values.size() >= 2);
+  return uint64_t(values[0]) | (uint64_t(values[1]) << 32);
+}
+
 uint32_t CFG_parse_signal(std::string& signal_str, std::string& name,
                           uint32_t& bit_start, uint32_t& bit_end,
                           uint32_t& bit_width, uint32_t& value) {

--- a/src/ConfigurationRS/Ocla/OclaHelpers.cpp
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.cpp
@@ -59,9 +59,11 @@ uint32_t CFG_reverse_byte_order_u32(uint32_t value) {
 
 void CFG_set_bitfield_u32(uint32_t& value, uint8_t pos, uint8_t width,
                           uint32_t data) {
+  CFG_ASSERT(width > 0);
+  CFG_ASSERT(width + pos <= 32);
   uint32_t mask = (~0u >> (32 - width)) << pos;
   value &= ~mask;
-  value |= (data & ((1u << width) - 1)) << pos;
+  value |= (data << pos) & mask;
 }
 
 uint32_t CFG_read_bit_vec32(uint32_t* data, uint32_t pos) {
@@ -73,7 +75,11 @@ uint32_t CFG_read_bit_vec32(uint32_t* data, uint32_t pos) {
 void CFG_write_bit_vec32(uint32_t* data, uint32_t pos, uint32_t value) {
   // callee should make sure data ptr not out of bound
   CFG_ASSERT(data != nullptr);
-  data[pos / 32] |= value << (pos % 32);
+  uint32_t mask = 1u << (pos % 32);
+  data[pos / 32] &= ~mask;
+  if (value) {
+    data[pos / 32] |= mask;
+  }
 }
 
 void CFG_copy_bits_vec32(uint32_t* data, uint32_t pos, uint32_t* output,
@@ -82,7 +88,7 @@ void CFG_copy_bits_vec32(uint32_t* data, uint32_t pos, uint32_t* output,
   CFG_ASSERT(data != nullptr);
   CFG_ASSERT(output != nullptr);
   // naive implementation that does the copying bit by bit.
-  // this is till ok for small dataset.
+  // this is still ok for small dataset.
   for (uint32_t i = 0; i < nbits; i++) {
     CFG_write_bit_vec32(output, output_pos + i,
                         CFG_read_bit_vec32(data, pos + i));

--- a/src/ConfigurationRS/Ocla/OclaHelpers.cpp
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.cpp
@@ -100,8 +100,11 @@ std::vector<uint32_t> CFG_convert_u64_to_vec_u32(uint64_t value) {
 }
 
 uint64_t CFG_convert_vec_u32_to_u64(std::vector<uint32_t> values) {
-  CFG_ASSERT(values.size() >= 2);
-  return uint64_t(values[0]) | (uint64_t(values[1]) << 32);
+  CFG_ASSERT(values.size() >= 1);
+  if (values.size() > 1) {
+    return uint64_t(values[0]) | (uint64_t(values[1]) << 32);
+  }
+  return uint64_t(values[0]);
 }
 
 uint32_t CFG_parse_signal(std::string& signal_str, std::string& name,

--- a/src/ConfigurationRS/Ocla/OclaHelpers.h
+++ b/src/ConfigurationRS/Ocla/OclaHelpers.h
@@ -52,6 +52,10 @@ void CFG_write_bit_vec32(uint32_t *data, uint32_t pos, uint32_t value);
 void CFG_copy_bits_vec32(uint32_t *src, uint32_t pos, uint32_t *dest,
                          uint32_t dest_pos, uint32_t nbits);
 
+std::vector<uint32_t> CFG_convert_u64_to_vec_u32(uint64_t value);
+
+uint64_t CFG_convert_vec_u32_to_u64(std::vector<uint32_t> values);
+
 uint32_t CFG_parse_signal(std::string &signal_str, std::string &name,
                           uint32_t &bit_start, uint32_t &bit_end,
                           uint32_t &bit_width, uint32_t &value);

--- a/src/ConfigurationRS/Ocla/Ocla_entry.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla_entry.cpp
@@ -181,6 +181,18 @@ void Ocla_entry(CFGCommon_ARG* cmdarg) {
                            parms->device)) {
       ocla.show_instance_info();
     }
+  } else if (subcmd == "set_io") {
+    auto parms = static_cast<const CFGArg_DEBUGGER_SET_IO*>(arg->get_sub_arg());
+    if (Ocla_select_device(adapter, hardware_manager, parms->cable,
+                           parms->device)) {
+      CFG_POST_MSG("Not implemented");
+    }
+  } else if (subcmd == "get_io") {
+    auto parms = static_cast<const CFGArg_DEBUGGER_GET_IO*>(arg->get_sub_arg());
+    if (Ocla_select_device(adapter, hardware_manager, parms->cable,
+                           parms->device)) {
+      CFG_POST_MSG("Not implemented");
+    }
   } else if (subcmd == "read") {
     auto parms = static_cast<const CFGArg_DEBUGGER_READ*>(arg->get_sub_arg());
     if (Ocla_select_device(adapter, hardware_manager, parms->cable,

--- a/src/ConfigurationRS/Ocla/Ocla_entry.cpp
+++ b/src/ConfigurationRS/Ocla/Ocla_entry.cpp
@@ -185,13 +185,35 @@ void Ocla_entry(CFGCommon_ARG* cmdarg) {
     auto parms = static_cast<const CFGArg_DEBUGGER_SET_IO*>(arg->get_sub_arg());
     if (Ocla_select_device(adapter, hardware_manager, parms->cable,
                            parms->device)) {
-      CFG_POST_MSG("Not implemented");
+      ocla.set_io(parms->signal, parms->value);
     }
   } else if (subcmd == "get_io") {
     auto parms = static_cast<const CFGArg_DEBUGGER_GET_IO*>(arg->get_sub_arg());
     if (Ocla_select_device(adapter, hardware_manager, parms->cable,
                            parms->device)) {
-      CFG_POST_MSG("Not implemented");
+      for (uint64_t i = 0; i < parms->loop; i++) {
+        std::vector<eio_value_t> values{};
+        std::string output{};
+        bool first = true;
+        if (!ocla.get_io(parms->signal, values)) {
+          break;
+        }
+        if (values.size() != parms->signal.size()) {
+          CFG_POST_ERR("Result value length mismatched (expect=%d, actual=%d)",
+                       parms->signal.size(), values.size());
+          break;
+        }
+        for (auto& v : values) {
+          if (!first) {
+            output += ", " + v.signal_name + " = " + std::to_string(v.value);
+          } else {
+            output += v.signal_name + " = " + std::to_string(v.value);
+            first = false;
+          }
+        }
+        CFG_POST_MSG("#%d: %s", i, output.c_str());
+        CFG_sleep_ms((uint32_t)parms->duration);
+      }
     }
   } else if (subcmd == "read") {
     auto parms = static_cast<const CFGArg_DEBUGGER_READ*>(arg->get_sub_arg());

--- a/src/ConfigurationRS/Ocla/Test/EioIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/EioIpTests.cpp
@@ -39,7 +39,8 @@ TEST_F(EioIPTest, read_lower_test) {
 }
 
 TEST_F(EioIPTest, read_upper_test) {
-  ON_CALL(mockAdapter, read(EIO_AXI_DAT_IN + 4)).WillByDefault(Return(0x87654321));
+  ON_CALL(mockAdapter, read(EIO_AXI_DAT_IN + 4))
+      .WillByDefault(Return(0x87654321));
   EioIP eio(&mockAdapter, 0);
   auto result = eio.read(eio_probe_register_t::UPPER);
   ASSERT_EQ(result, 0x87654321);

--- a/src/ConfigurationRS/Ocla/Test/EioIpTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/EioIpTests.cpp
@@ -1,0 +1,79 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <memory>
+#include <tuple>
+
+#include "EioIP.h"
+#include "OclaJtagAdapter.h"
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+class MockOclaJtagAdapter : public OclaJtagAdapter {
+ public:
+  MOCK_METHOD(void, write, (uint32_t addr, uint32_t data), (override));
+  MOCK_METHOD(uint32_t, read, (uint32_t addr), (override));
+  MOCK_METHOD(std::vector<jtag_read_result>, read,
+              (uint32_t base_addr, uint32_t num_reads, uint32_t increase_by),
+              (override));
+  MOCK_METHOD(void, set_target_device,
+              (FOEDAG::Device device, std::vector<FOEDAG::Tap> taps),
+              (override));
+};
+
+class EioIPTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+  NiceMock<MockOclaJtagAdapter> mockAdapter;
+};
+
+TEST_F(EioIPTest, read_lower_test) {
+  ON_CALL(mockAdapter, read(EIO_AXI_DAT_IN)).WillByDefault(Return(0x12345678));
+  EioIP eio(&mockAdapter, 0);
+  auto result = eio.read(eio_probe_register_t::LOWER);
+  ASSERT_EQ(result, 0x12345678);
+}
+
+TEST_F(EioIPTest, read_upper_test) {
+  ON_CALL(mockAdapter, read(EIO_AXI_DAT_IN + 4)).WillByDefault(Return(0x87654321));
+  EioIP eio(&mockAdapter, 0);
+  auto result = eio.read(eio_probe_register_t::UPPER);
+  ASSERT_EQ(result, 0x87654321);
+}
+
+TEST_F(EioIPTest, write_lower_test) {
+  EXPECT_CALL(mockAdapter, write(EIO_AXI_DAT_IN, 0xa55aa5a5));
+  EioIP eio(&mockAdapter, 0);
+  eio.write(0xa55aa5a5, eio_probe_register_t::LOWER);
+}
+
+TEST_F(EioIPTest, write_upper_test) {
+  EXPECT_CALL(mockAdapter, write(EIO_AXI_DAT_IN + 4, 0xdeadbeef));
+  EioIP eio(&mockAdapter, 0);
+  eio.write(0xdeadbeef, eio_probe_register_t::UPPER);
+}
+
+TEST_F(EioIPTest, get_type_test) {
+  ON_CALL(mockAdapter, read(EIO_IP_TYPE)).WillByDefault(Return(0x0045494f));
+  EioIP eio(&mockAdapter, 0);
+  auto result = eio.get_type();
+  ASSERT_EQ(result, "EIO");
+}
+
+TEST_F(EioIPTest, get_version_test) {
+  ON_CALL(mockAdapter, read(EIO_IP_VERSION)).WillByDefault(Return(0x1));
+  EioIP eio(&mockAdapter, 0);
+  auto result = eio.get_version();
+  ASSERT_EQ(result, 0x1);
+}
+
+TEST_F(EioIPTest, get_id_test) {
+  ON_CALL(mockAdapter, read(EIO_IP_ID)).WillByDefault(Return(0x012343210));
+  EioIP eio(&mockAdapter, 0);
+  auto result = eio.get_id();
+  ASSERT_EQ(result, 0x012343210);
+}

--- a/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
@@ -228,7 +228,8 @@ TEST(CFG_toupperTest, CFG_toupper_test) {
 }
 
 TEST(ReadWriteBitsVectorUint32Test, CFG_read_bit_vec32_test) {
-  std::vector<uint32_t> test_vector{0xa5a55a5a, 0xdeadbeef, 0xffff0000, 0xabcd1234, 0x76543210};
+  std::vector<uint32_t> test_vector{0xa5a55a5a, 0xdeadbeef, 0xffff0000,
+                                    0xabcd1234, 0x76543210};
   std::vector<uint32_t> vector(5, 0);
 
   for (int i = 0; i < (32 * int(test_vector.size())); i++) {
@@ -242,23 +243,25 @@ TEST(ReadWriteBitsVectorUint32Test, CFG_read_bit_vec32_test) {
 }
 
 TEST(ReadWriteBitsVectorUint32Test, CFG_write_bit_vec32) {
-  std::vector<uint32_t> test_vector{0xa5a55a5a, 0xdeadbeef, 0xffff0000, 0xabcd1234, 0x76543210};
+  std::vector<uint32_t> test_vector{0xa5a55a5a, 0xdeadbeef, 0xffff0000,
+                                    0xabcd1234, 0x76543210};
   std::vector<uint32_t> vector(5, -1);
 
   for (int i = 0; i < (32 * int(test_vector.size())); i++) {
-    CFG_write_bit_vec32(vector.data(), i, test_vector[i / 32] & (1u << (i % 32)));
+    CFG_write_bit_vec32(vector.data(), i,
+                        test_vector[i / 32] & (1u << (i % 32)));
   }
 
   EXPECT_EQ(vector, test_vector);
 }
 
 TEST(ReadWriteBitsVectorUint32Test, CFG_copy_bits_vec32) {
-  std::vector<uint32_t> test_vector{
-    0x3A8FBCD2, 0x7E2D9F54, 0x9C0A6B71, 0x5F184E3D, 0xA39215E8,
-    0x1B6C8D9A, 0xE71FAB2F, 0x4D0E62F6, 0x82F573C9};
-  std::vector<uint32_t> expected_vector{
-    0x3A8FBCFF, 0x7E2D9F54, 0x9C0A6B71, 0x5F184E3D, 0xA39215E8,
-    0x1B6C8D9A, 0xE71FAB2F, 0x4D0E62F6, 0xFFF573C9};
+  std::vector<uint32_t> test_vector{0x3A8FBCD2, 0x7E2D9F54, 0x9C0A6B71,
+                                    0x5F184E3D, 0xA39215E8, 0x1B6C8D9A,
+                                    0xE71FAB2F, 0x4D0E62F6, 0x82F573C9};
+  std::vector<uint32_t> expected_vector{0x3A8FBCFF, 0x7E2D9F54, 0x9C0A6B71,
+                                        0x5F184E3D, 0xA39215E8, 0x1B6C8D9A,
+                                        0xE71FAB2F, 0x4D0E62F6, 0xFFF573C9};
   std::vector<uint32_t> vector(9, 0xffffffff);
 
   for (int i = 7; i < (32 * int(test_vector.size())) - 8; i += 7) {
@@ -268,16 +271,18 @@ TEST(ReadWriteBitsVectorUint32Test, CFG_copy_bits_vec32) {
   EXPECT_EQ(vector, expected_vector);
 }
 
-class ReverseByteOrderU32Test : public ::testing::TestWithParam<std::tuple<uint32_t, uint32_t>> {
-protected:
-    void SetUp() override {}
-    void TearDown() override {}
+class ReverseByteOrderU32Test
+    : public ::testing::TestWithParam<std::tuple<uint32_t, uint32_t>> {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
 };
 
-INSTANTIATE_TEST_SUITE_P(Default, ReverseByteOrderU32Test,
-                        ::testing::Values(std::make_tuple(0x01020304, 0x04030201),
-                                          std::make_tuple(0x12345678, 0x78563412),
-                                          std::make_tuple(0x1111FFFF, 0xFFFF1111)));
+INSTANTIATE_TEST_SUITE_P(
+    Default, ReverseByteOrderU32Test,
+    ::testing::Values(std::make_tuple(0x01020304, 0x04030201),
+                      std::make_tuple(0x12345678, 0x78563412),
+                      std::make_tuple(0x1111FFFF, 0xFFFF1111)));
 
 TEST_P(ReverseByteOrderU32Test, CFG_reverse_byte_order_u32_test) {
   uint32_t input = std::get<0>(GetParam());
@@ -286,19 +291,21 @@ TEST_P(ReverseByteOrderU32Test, CFG_reverse_byte_order_u32_test) {
   EXPECT_EQ(output, expected_output);
 }
 
-class SetBitfieldU32Test : public ::testing::TestWithParam<std::tuple<uint32_t, uint8_t, uint8_t, uint32_t, uint32_t>> {
-protected:
-    void SetUp() override {}
-    void TearDown() override {}
+class SetBitfieldU32Test
+    : public ::testing::TestWithParam<
+          std::tuple<uint32_t, uint8_t, uint8_t, uint32_t, uint32_t>> {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
 };
 
-INSTANTIATE_TEST_SUITE_P(Default, SetBitfieldU32Test,
-                        ::testing::Values(
-                                          std::make_tuple(0x00000000, 7, 5, 31, 0x00000f80),
-                                          std::make_tuple(0xffffffff, 21, 7, 0, 0xf01fffff),
-                                          std::make_tuple(0x00000000, 0, 32, 0xdeadbeef, 0xdeadbeef),
-                                          std::make_tuple(0x00000001, 1, 31, 0xdeadbeef, 0xbd5b7ddf)
-                                          ));
+INSTANTIATE_TEST_SUITE_P(
+    Default, SetBitfieldU32Test,
+    ::testing::Values(
+        std::make_tuple(0x00000000, 7, 5, 31, 0x00000f80),
+        std::make_tuple(0xffffffff, 21, 7, 0, 0xf01fffff),
+        std::make_tuple(0x00000000, 0, 32, 0xdeadbeef, 0xdeadbeef),
+        std::make_tuple(0x00000001, 1, 31, 0xdeadbeef, 0xbd5b7ddf)));
 
 TEST_P(SetBitfieldU32Test, CFG_set_bitfield_u32_test) {
   uint32_t value = std::get<0>(GetParam());
@@ -310,19 +317,26 @@ TEST_P(SetBitfieldU32Test, CFG_set_bitfield_u32_test) {
   EXPECT_EQ(value, expected_value);
 }
 
-class ParseSignalTest : public ::testing::TestWithParam<std::tuple<std::string, std::string, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t>> {
-protected:
-    void SetUp() override {}
-    void TearDown() override {}
+class ParseSignalTest
+    : public ::testing::TestWithParam<
+          std::tuple<std::string, std::string, uint32_t, uint32_t, uint32_t,
+                     uint32_t, uint32_t>> {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
 };
 
-INSTANTIATE_TEST_SUITE_P(Default, ParseSignalTest,
-                        ::testing::Values(std::make_tuple("counter[31:1]", "counter", 1, 31, 0, 0, OCLA_SIGNAL_PATTERN_1),
-                                          std::make_tuple("8'10011001", "8'10011001", 0, 0, 8, 153, OCLA_SIGNAL_PATTERN_2),
-                                          std::make_tuple("addr[5]", "addr", 5, 5, 0, 0, OCLA_SIGNAL_PATTERN_3),
-                                          std::make_tuple("3", "3", 0, 0, 0, 3, OCLA_SIGNAL_PATTERN_4),
-                                          std::make_tuple("abc", "abc", 0, 0, 0, 0, OCLA_SIGNAL_PATTERN_5),
-                                          std::make_tuple("#123ABC", "", 0, 0, 0, 0, 0)));
+INSTANTIATE_TEST_SUITE_P(
+    Default, ParseSignalTest,
+    ::testing::Values(
+        std::make_tuple("counter[31:1]", "counter", 1, 31, 0, 0,
+                        OCLA_SIGNAL_PATTERN_1),
+        std::make_tuple("8'10011001", "8'10011001", 0, 0, 8, 153,
+                        OCLA_SIGNAL_PATTERN_2),
+        std::make_tuple("addr[5]", "addr", 5, 5, 0, 0, OCLA_SIGNAL_PATTERN_3),
+        std::make_tuple("3", "3", 0, 0, 0, 3, OCLA_SIGNAL_PATTERN_4),
+        std::make_tuple("abc", "abc", 0, 0, 0, 0, OCLA_SIGNAL_PATTERN_5),
+        std::make_tuple("#123ABC", "", 0, 0, 0, 0, 0)));
 
 TEST_P(ParseSignalTest, CFG_parse_signal_test) {
   std::string signal_str = std::get<0>(GetParam());

--- a/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
+++ b/src/ConfigurationRS/Ocla/Test/OclaHelpersTests.cpp
@@ -159,7 +159,6 @@ TEST(ConvertTriggerTypeTest, ValidTriggerType) {
       {EDGE, "edge"},
       {LEVEL, "level"},
       {VALUE_COMPARE, "value_compare"}};
-  // ocla_trigger_type expected = ocla_trigger_type::TRIGGER_NONE;
   for (const auto& [expected, param] : testParam) {
     std::string type_string = param;
     ocla_trigger_type result = convert_trigger_type(type_string);
@@ -194,7 +193,6 @@ TEST(ConvertTriggerEventTest, ValidTriggerType) {
       {EITHER, "either"},         {LOW, "low"},       {HIGH, "high"},
       {VALUE_NONE, "value_none"}, {EQUAL, "equal"},   {LESSER, "lesser"},
       {GREATER, "greater"}};
-  // ocla_trigger_type expected = ocla_trigger_type::TRIGGER_NONE;
   for (const auto& [expected, param] : testParam) {
     std::string type_string = param;
     ocla_trigger_event result = convert_trigger_event(type_string);
@@ -221,4 +219,129 @@ TEST(ConvertTriggerEventTest, defaultTriggerType) {
   ocla_trigger_event expected = NO_EVENT;
   ocla_trigger_event result = convert_trigger_event(type_string, NO_EVENT);
   EXPECT_EQ(result, expected);
+}
+
+TEST(CFG_toupperTest, CFG_toupper_test) {
+  std::string test_string = "helloworld!!!";
+  auto result = CFG_toupper(test_string);
+  EXPECT_EQ(result, "HELLOWORLD!!!");
+}
+
+TEST(ReadWriteBitsVectorUint32Test, CFG_read_bit_vec32_test) {
+  std::vector<uint32_t> test_vector{0xa5a55a5a, 0xdeadbeef, 0xffff0000, 0xabcd1234, 0x76543210};
+  std::vector<uint32_t> vector(5, 0);
+
+  for (int i = 0; i < (32 * int(test_vector.size())); i++) {
+    uint32_t bit = CFG_read_bit_vec32(test_vector.data(), i);
+    if (bit) {
+      vector[i / 32] |= (1u << (i % 32));
+    }
+  }
+
+  EXPECT_EQ(vector, test_vector);
+}
+
+TEST(ReadWriteBitsVectorUint32Test, CFG_write_bit_vec32) {
+  std::vector<uint32_t> test_vector{0xa5a55a5a, 0xdeadbeef, 0xffff0000, 0xabcd1234, 0x76543210};
+  std::vector<uint32_t> vector(5, -1);
+
+  for (int i = 0; i < (32 * int(test_vector.size())); i++) {
+    CFG_write_bit_vec32(vector.data(), i, test_vector[i / 32] & (1u << (i % 32)));
+  }
+
+  EXPECT_EQ(vector, test_vector);
+}
+
+TEST(ReadWriteBitsVectorUint32Test, CFG_copy_bits_vec32) {
+  std::vector<uint32_t> test_vector{
+    0x3A8FBCD2, 0x7E2D9F54, 0x9C0A6B71, 0x5F184E3D, 0xA39215E8,
+    0x1B6C8D9A, 0xE71FAB2F, 0x4D0E62F6, 0x82F573C9};
+  std::vector<uint32_t> expected_vector{
+    0x3A8FBCFF, 0x7E2D9F54, 0x9C0A6B71, 0x5F184E3D, 0xA39215E8,
+    0x1B6C8D9A, 0xE71FAB2F, 0x4D0E62F6, 0xFFF573C9};
+  std::vector<uint32_t> vector(9, 0xffffffff);
+
+  for (int i = 7; i < (32 * int(test_vector.size())) - 8; i += 7) {
+    CFG_copy_bits_vec32(test_vector.data(), i, vector.data(), i, 7);
+  }
+
+  EXPECT_EQ(vector, expected_vector);
+}
+
+class ReverseByteOrderU32Test : public ::testing::TestWithParam<std::tuple<uint32_t, uint32_t>> {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+INSTANTIATE_TEST_SUITE_P(Default, ReverseByteOrderU32Test,
+                        ::testing::Values(std::make_tuple(0x01020304, 0x04030201),
+                                          std::make_tuple(0x12345678, 0x78563412),
+                                          std::make_tuple(0x1111FFFF, 0xFFFF1111)));
+
+TEST_P(ReverseByteOrderU32Test, CFG_reverse_byte_order_u32_test) {
+  uint32_t input = std::get<0>(GetParam());
+  uint32_t expected_output = std::get<1>(GetParam());
+  auto output = CFG_reverse_byte_order_u32(input);
+  EXPECT_EQ(output, expected_output);
+}
+
+class SetBitfieldU32Test : public ::testing::TestWithParam<std::tuple<uint32_t, uint8_t, uint8_t, uint32_t, uint32_t>> {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+INSTANTIATE_TEST_SUITE_P(Default, SetBitfieldU32Test,
+                        ::testing::Values(
+                                          std::make_tuple(0x00000000, 7, 5, 31, 0x00000f80),
+                                          std::make_tuple(0xffffffff, 21, 7, 0, 0xf01fffff),
+                                          std::make_tuple(0x00000000, 0, 32, 0xdeadbeef, 0xdeadbeef),
+                                          std::make_tuple(0x00000001, 1, 31, 0xdeadbeef, 0xbd5b7ddf)
+                                          ));
+
+TEST_P(SetBitfieldU32Test, CFG_set_bitfield_u32_test) {
+  uint32_t value = std::get<0>(GetParam());
+  uint32_t pos = std::get<1>(GetParam());
+  uint32_t width = std::get<2>(GetParam());
+  uint32_t data = std::get<3>(GetParam());
+  uint32_t expected_value = std::get<4>(GetParam());
+  CFG_set_bitfield_u32(value, pos, width, data);
+  EXPECT_EQ(value, expected_value);
+}
+
+class ParseSignalTest : public ::testing::TestWithParam<std::tuple<std::string, std::string, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t>> {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+INSTANTIATE_TEST_SUITE_P(Default, ParseSignalTest,
+                        ::testing::Values(std::make_tuple("counter[31:1]", "counter", 1, 31, 0, 0, OCLA_SIGNAL_PATTERN_1),
+                                          std::make_tuple("8'10011001", "8'10011001", 0, 0, 8, 153, OCLA_SIGNAL_PATTERN_2),
+                                          std::make_tuple("addr[5]", "addr", 5, 5, 0, 0, OCLA_SIGNAL_PATTERN_3),
+                                          std::make_tuple("3", "3", 0, 0, 0, 3, OCLA_SIGNAL_PATTERN_4),
+                                          std::make_tuple("abc", "abc", 0, 0, 0, 0, OCLA_SIGNAL_PATTERN_5),
+                                          std::make_tuple("#123ABC", "", 0, 0, 0, 0, 0)));
+
+TEST_P(ParseSignalTest, CFG_parse_signal_test) {
+  std::string signal_str = std::get<0>(GetParam());
+  std::string expected_name = std::get<1>(GetParam());
+  uint32_t expected_start = std::get<2>(GetParam());
+  uint32_t expected_end = std::get<3>(GetParam());
+  uint32_t expected_width = std::get<4>(GetParam());
+  uint32_t expected_value = std::get<5>(GetParam());
+  uint32_t expected_result = std::get<6>(GetParam());
+  uint32_t start = 0;
+  uint32_t end = 0;
+  uint32_t width = 0;
+  uint32_t value = 0;
+  std::string name = "";
+  auto result = CFG_parse_signal(signal_str, name, start, end, width, value);
+  EXPECT_EQ(result, expected_result);
+  EXPECT_EQ(name, expected_name);
+  EXPECT_EQ(start, expected_start);
+  EXPECT_EQ(end, expected_end);
+  EXPECT_EQ(width, expected_width);
+  EXPECT_EQ(value, expected_value);
 }


### PR DESCRIPTION
This PR enables the support for the EIO feature of the Debug IP in addition to OCLA. The PR implemented the CLI commands below:-

1. debugger info - To show EIO information in addition to OCLA information loaded from a user design
2. set_io - To change the output IO signal state
3. get_io - To read the input IO signal states

Screenshot:-
![image](https://github.com/os-fpga/FOEDAG_rs/assets/12110149/badbe990-b3c3-4d36-b9ad-66a5866a2932)
