### PR TITLE
Support PCB with Parity via JOSN. Correct spelling

### DIFF
--- a/src/ConfigurationRS/BitGenerator/BitGen_gemini.cpp
+++ b/src/ConfigurationRS/BitGenerator/BitGen_gemini.cpp
@@ -171,7 +171,7 @@ void BitGen_GEMINI::generate(std::vector<BitGen_BITSTREAM_BOP*>& data) {
     pcb["pl_col_stride"] = col_stride;
     // clang-format off
   #if PCB_CONFIG_INCLUDE_PARITY
-    pcb["reversed"] = 0;
+    pcb["reserved"] = 0;
   #else
     pcb["pl_extra_w32"] = 0;
     pcb["pl_extra_w33"] = 0;
@@ -266,7 +266,7 @@ void BitGen_GEMINI::generate(std::vector<BitGen_BITSTREAM_BOP*>& data) {
       pcb["pl_col_stride"] = col_stride;
       // clang-format off
   #if PCB_CONFIG_INCLUDE_PARITY
-      pcb["reversed"] = 0;
+      pcb["reserved"] = 0;
   #else
       pcb["pl_extra_w32"] = 0;
       pcb["pl_extra_w33"] = 0;

--- a/src/ConfigurationRS/BitGenerator/BitGen_json.cpp
+++ b/src/ConfigurationRS/BitGenerator/BitGen_json.cpp
@@ -293,7 +293,7 @@ const std::map<const std::string, const BitGen_JSON_ACTION_FIELD>
           {"pl_row_stride", std::make_pair(80, 10)},
           {"pl_col_offset", std::make_pair(96, 10)},
           {"pl_col_stride", std::make_pair(112, 10)},
-          {"reversed", std::make_pair(128, 32)}}}};
+          {"reserved", std::make_pair(128, 32)}}}};
 
 static const BitGen_JSON_ACTION_FIELD* BitGen_JSON_get_action_database(
     const std::string& action) {
@@ -430,6 +430,8 @@ static void BitGen_JSON_parse_bitstream_bop_action(
     actions.push_back(BitGen_JSON::gen_icb_config_action(json));
   } else if (action == "pcb_config") {
     actions.push_back(BitGen_JSON::gen_pcb_config_action(json));
+  } else if (action == "pcb_config_with_parity") {
+    actions.push_back(BitGen_JSON::gen_pcb_config_with_parity_action(json));
   } else if (action == "authentication_key_otp_programming") {
     actions.push_back(BitGen_JSON::gen_auth_key_otp_programming_action(json));
   } else if (action == "aes_key_otp_programming") {

--- a/src/ConfigurationRS/BitGenerator/BitGenerator.cpp
+++ b/src/ConfigurationRS/BitGenerator/BitGenerator.cpp
@@ -44,8 +44,9 @@ bool BitGenerator_entry(const CFGCommon_ARG* cmdarg) {
             0 ||
         CFG_check_file_extensions(subarg->m_args[1], {".cfgbit"}) < 0) {
       CFG_POST_ERR(
-          "BITGEN: parse::, input should be in .bitasm or .cfgbit extension, "
-          "and output should be in .debug.txt extension");
+          "BITGEN: gen_bitstream:: input should be in .bitasm or .json "
+          "extension, "
+          "and output should be in .cfgbit extension");
       status = false;
     }
     status = status && read_aes_key(subarg->aes_key, aes_key);
@@ -100,7 +101,7 @@ bool BitGenerator_entry(const CFGCommon_ARG* cmdarg) {
             0 ||
         CFG_check_file_extensions(subarg->m_args[1], {".debug.txt"}) < 0) {
       CFG_POST_ERR(
-          "BITGEN: parse::, input should be in .bitasm or .cfgbit extension, "
+          "BITGEN: parse:: input should be in .bitasm or .cfgbit extension, "
           "and output should be in .debug.txt extension");
       status = false;
     }


### PR DESCRIPTION
1. Correct the naming "reversed" -> "reserved"
2. Correct the printed message
3. Support "PCB config with parity" action in JSON customized bitstream generation (internal feature) 