### PR TITLE
EIO IP readback output IO state support

### DIFF
--- a/src/ConfigurationRS/Ocla/EioIP.cpp
+++ b/src/ConfigurationRS/Ocla/EioIP.cpp
@@ -30,6 +30,17 @@ uint32_t EioIP::get_version() const { return m_version; }
 
 uint32_t EioIP::get_id() const { return m_id; }
 
+eio_prs_mode EioIP::get_prs_mode() const {
+  return (eio_prs_mode)((m_ctrl & EIO_CTRL_PRS_Msk) >> EIO_CTRL_PRS_Pos);
+}
+
+void EioIP::set_prs_mode(eio_prs_mode mode) {
+  CFG_ASSERT(m_adapter != nullptr);
+  CFG_set_bitfield_u32(m_ctrl, EIO_CTRL_PRS_Pos, EIO_CTRL_PRS_Width,
+                       (uint32_t)(mode));
+  m_adapter->write(m_baseaddr + EIO_CTRL, m_ctrl);
+}
+
 void EioIP::write_output_bits(std::vector<uint32_t> values, uint32_t length) {
   CFG_ASSERT(m_adapter != nullptr);
   CFG_ASSERT(length > 0);
@@ -40,16 +51,35 @@ void EioIP::write_output_bits(std::vector<uint32_t> values, uint32_t length) {
   }
 }
 
-std::vector<uint32_t> EioIP::read_input_bits(uint32_t length) {
-  CFG_ASSERT(m_adapter != nullptr);
-  CFG_ASSERT(length > 0);
-  CFG_ASSERT(length <= MAX_IO_INPUT_REG);
+std::vector<uint32_t> EioIP::read_bits(uint32_t addr, uint32_t length) {
   std::vector<uint32_t> values{};
-  auto result = m_adapter->read(m_baseaddr + EIO_AXI_DAT_IN, length, 4);
+  auto result = m_adapter->read(addr, length, 4);
   for (auto &r : result) {
     values.push_back(r.data);
   }
   return values;
+}
+
+std::vector<uint32_t> EioIP::readback_output_bits(uint32_t length) {
+  CFG_ASSERT(m_adapter != nullptr);
+  CFG_ASSERT(length > 0);
+  CFG_ASSERT(length <= MAX_IO_OUTPUT_REG);
+  // make sure probe read selection bit is set (Read Probe-Out-Register)
+  if (get_prs_mode() == eio_prs_mode::PROBE_IN) {
+    set_prs_mode(eio_prs_mode::PROBE_OUT);
+  }
+  return read_bits(m_baseaddr + EIO_AXI_DAT_OUT, length);
+}
+
+std::vector<uint32_t> EioIP::read_input_bits(uint32_t length) {
+  CFG_ASSERT(m_adapter != nullptr);
+  CFG_ASSERT(length > 0);
+  CFG_ASSERT(length <= MAX_IO_INPUT_REG);
+  // make sure probe read selection bit is clear (Read Probe-In-Register)
+  if (get_prs_mode() == eio_prs_mode::PROBE_OUT) {
+    set_prs_mode(eio_prs_mode::PROBE_IN);
+  }
+  return read_bits(m_baseaddr + EIO_AXI_DAT_IN, length);
 }
 
 void EioIP::read_registers() {

--- a/src/ConfigurationRS/Ocla/EioIP.h
+++ b/src/ConfigurationRS/Ocla/EioIP.h
@@ -14,7 +14,14 @@
 #define EIO_AXI_DAT_OUT \
   (0x10)  // [WO] Data at the output probes of EIO (sent to the DUT)
 
+// CTRL (Control register) bitfield definitions
+#define EIO_CTRL_PRS_Pos (0)
+#define EIO_CTRL_PRS_Width (1)
+#define EIO_CTRL_PRS_Msk (((1u << EIO_CTRL_PRS_Width) - 1) << EIO_CTRL_PRS_Pos)
+
 class OclaJtagAdapter;
+
+enum eio_prs_mode { PROBE_IN = 0, PROBE_OUT = 1 };
 
 class EioIP {
  public:
@@ -23,11 +30,14 @@ class EioIP {
   std::string get_type() const;
   uint32_t get_version() const;
   uint32_t get_id() const;
+  eio_prs_mode get_prs_mode() const;
+  void set_prs_mode(eio_prs_mode mode);
   void write_output_bits(std::vector<uint32_t> values, uint32_t length);
   std::vector<uint32_t> readback_output_bits(uint32_t length);
   std::vector<uint32_t> read_input_bits(uint32_t length);
 
  private:
+  std::vector<uint32_t> read_bits(uint32_t addr, uint32_t length);
   void read_registers();
   OclaJtagAdapter *m_adapter;
   uint32_t m_baseaddr;

--- a/src/ConfigurationRS/Ocla/EioInstance.cpp
+++ b/src/ConfigurationRS/Ocla/EioInstance.cpp
@@ -16,12 +16,12 @@ void EioInstance::add_probe(eio_probe_t& probe) { m_probes.push_back(probe); }
 
 std::vector<eio_probe_t>& EioInstance::get_probes() { return m_probes; }
 
-uint32_t EioInstance::get_total_probe_width(eio_probe_type_t type) const {
+uint32_t EioInstance::get_num_words(eio_probe_type_t type) const {
   uint32_t width = 0;
   for (auto& probe : m_probes) {
     if (probe.type == type) {
       width += probe.probe_width;
     }
   }
-  return width;
+  return ((width - 1) / 32) + 1;
 }

--- a/src/ConfigurationRS/Ocla/EioInstance.h
+++ b/src/ConfigurationRS/Ocla/EioInstance.h
@@ -28,14 +28,9 @@ class EioInstance {
   ~EioInstance();
   std::vector<eio_probe_t>& get_probes();
   void add_probe(eio_probe_t& probe);
-  uint32_t get_total_probe_width(eio_probe_type_t type) const;
+  uint32_t get_num_words(eio_probe_type_t type) const;
   uint32_t get_baseaddr() const;
   uint32_t get_index() const;
-
-  // Caveat 1:
-  // Keep the output io signal state for RMW operation to the IP until EIO
-  // implemented the readback capability
-  std::vector<uint32_t> output_state;
 
  private:
   uint32_t m_baseaddr;


### PR DESCRIPTION
This PR updated to make use the EIO IP readback capability to read the current output IO state instead of software to keep track the state in local memory.

Changes:-
1. Update the low level EIO IP driver to support output IO readback capability of the EIO IP
2. Use IP readback capability to get the current output IO for RMW operations
3. Remove the temporary code to keep track output io state due to IP lack of readback support
4. Add related unit tests
