### PR TITLE
Support ICB double configuration

### DIFF
--- a/src/ConfigurationRS/BitAssembler/BitAssembler.cpp
+++ b/src/ConfigurationRS/BitAssembler/BitAssembler.cpp
@@ -63,6 +63,14 @@ void BitAssembler_entry(CFGCommon_ARG* cmdarg) {
     // ICB
     mgr.get_icb(&bitobj.icb);
 
+    // Post ICB
+    mgr.get_post_icb(&bitobj.post_icb);
+
+    if (bitobj.post_icb.bits) {
+      // If there is post ICB, ICB must exist
+      CFG_ASSERT(bitobj.icb.bits == bitobj.post_icb.bits);
+    }
+
     // PCB
     mgr.get_pcb(bitobj);
 

--- a/src/ConfigurationRS/BitAssembler/BitAssembler_mgr.h
+++ b/src/ConfigurationRS/BitAssembler/BitAssembler_mgr.h
@@ -14,6 +14,7 @@ class BitAssembler_MGR {
   void get_scan_chain_fcb(const CFGObject_BITOBJ_SCAN_CHAIN_FCB* fcb);
   void get_ql_membank_fcb(const CFGObject_BITOBJ_QL_MEMBANK_FCB* fcb);
   void get_icb(const CFGObject_BITOBJ_ICB* icb);
+  void get_post_icb(const CFGObject_BITOBJ_POST_ICB* icb);
   void get_pcb(CFGObject_BITOBJ& bitobj);
   std::vector<std::string> m_warnings;
 
@@ -35,6 +36,7 @@ class BitAssembler_MGR {
   static std::string get_ocla_design(const std::string& filepath);
 
  private:
+  uint32_t get_icb(const std::string& filepath, std::vector<uint8_t>& data);
   template <typename T>
   uint32_t get_bitline_into_bytes(T& start, T& end, std::vector<uint8_t>& bytes,
                                   std::vector<uint8_t>* mask_bytes,

--- a/src/ConfigurationRS/BitGenerator/BitGen_gemini.h
+++ b/src/ConfigurationRS/BitGenerator/BitGen_gemini.h
@@ -10,6 +10,8 @@ class BitGen_GEMINI {
   void generate(std::vector<BitGen_BITSTREAM_BOP*>& data);
 
  protected:
+  void icb_generate(BitGen_BITSTREAM_BOP*& bop, const uint32_t bits,
+                    const std::vector<uint8_t>& data);
   uint64_t convert_to(uint64_t value, uint64_t unit);
   uint64_t convert_to8(uint64_t value);
   uint64_t convert_to16(uint64_t value);

--- a/src/ConfigurationRS/CFGObject/CFGObject.json
+++ b/src/ConfigurationRS/CFGObject/CFGObject.json
@@ -96,6 +96,21 @@
       "exist" : false
     },
     {
+      "name" : "post_icb",
+      "type" : [
+        {
+          "name" : "bits",
+          "type" : "u32"
+        },
+        {
+          "name" : "data",
+          "type" : "u8s",
+          "cmp"  : true
+        }
+      ],
+      "exist" : false
+    },
+    {
       "name" : "pcb",
       "type" : [
         {

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -201,16 +201,19 @@ ocla_trigger_config OclaIP::get_channel_config(uint32_t channel) const {
 
   switch (cfg.type) {
     case EDGE:
-      cfg.event = (ocla_trigger_event)(
-          ((reg.tcur & TCUR_ET_Msk) >> TCUR_ET_Pos) | 0x10);
+      cfg.event =
+          (ocla_trigger_event)(((reg.tcur & TCUR_ET_Msk) >> TCUR_ET_Pos) |
+                               0x10);
       break;
     case LEVEL:
-      cfg.event = (ocla_trigger_event)(
-          ((reg.tcur & TCUR_LT_Msk) >> TCUR_LT_Pos) | 0x20);
+      cfg.event =
+          (ocla_trigger_event)(((reg.tcur & TCUR_LT_Msk) >> TCUR_LT_Pos) |
+                               0x20);
       break;
     case VALUE_COMPARE:
-      cfg.event = (ocla_trigger_event)(
-          ((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) | 0x30);
+      cfg.event =
+          (ocla_trigger_event)(((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) |
+                               0x30);
       cfg.value = reg.tdcr;
       cfg.compare_width = ((reg.tssr & TSSR_CW_Msk) >> TSSR_CW_Pos) + 1;
       break;

--- a/src/ConfigurationRS/Ocla/OclaIP.cpp
+++ b/src/ConfigurationRS/Ocla/OclaIP.cpp
@@ -201,19 +201,16 @@ ocla_trigger_config OclaIP::get_channel_config(uint32_t channel) const {
 
   switch (cfg.type) {
     case EDGE:
-      cfg.event =
-          (ocla_trigger_event)(((reg.tcur & TCUR_ET_Msk) >> TCUR_ET_Pos) |
-                               0x10);
+      cfg.event = (ocla_trigger_event)(
+          ((reg.tcur & TCUR_ET_Msk) >> TCUR_ET_Pos) | 0x10);
       break;
     case LEVEL:
-      cfg.event =
-          (ocla_trigger_event)(((reg.tcur & TCUR_LT_Msk) >> TCUR_LT_Pos) |
-                               0x20);
+      cfg.event = (ocla_trigger_event)(
+          ((reg.tcur & TCUR_LT_Msk) >> TCUR_LT_Pos) | 0x20);
       break;
     case VALUE_COMPARE:
-      cfg.event =
-          (ocla_trigger_event)(((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) |
-                               0x30);
+      cfg.event = (ocla_trigger_event)(
+          ((reg.tcur & TCUR_VC_Msk) >> TCUR_VC_Pos) | 0x30);
       cfg.value = reg.tdcr;
       cfg.compare_width = ((reg.tssr & TSSR_CW_Msk) >> TSSR_CW_Pos) + 1;
       break;


### PR DESCRIPTION
See https://github.com/os-fpga/FOEDAG/pull/1600

This PR:
   - port latest FOEDAG (https://github.com/os-fpga/FOEDAG/pull/1600) which has partial fix for this issue,
   - integrate possible io_bitstream.post.bit into .bitasm
   - generate bitstream (.bitcfg) with second ICB configuration if post ICB exists in .bitasm and it is different from ICB data. 

Testing done:
   - Port this PR to latest NS Raptor
   - Run test/batch, test/batch_gen2. test/batch_gen3