### PR TITLE
Update main.yml to use GCC 12 as GCC 11 is no longer available on macos image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -436,8 +436,8 @@ jobs:
 
     - name: Configure shell
       run: |
-        echo 'CC=gcc-11' >> $GITHUB_ENV
-        echo 'CXX=g++-11' >> $GITHUB_ENV
+        echo 'CC=gcc-12' >> $GITHUB_ENV
+        echo 'CXX=g++-12' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
         echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
         echo "$PREFIX" >> $GITHUB_PATH


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10213
GitHub MacOS 12 has no longer GCC-11 so bumping the GCC version to 12.