### PR TITLE
Use github runner os 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   linux-gcc:
     name: ubuntu-${{ matrix.mode }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -119,7 +119,7 @@ jobs:
 # Reference: https://github.com/OPM/ResInsight/blob/dev/.github/workflows/centos7.yml
   centos7-gcc:
     name:  centos7-${{ matrix.mode }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
GitHub Actions runners are now using Ubuntu 24.04 and we don't support it so using Ubuntu 22.04